### PR TITLE
Fix casing of `sphinx` in doc environment file

### DIFF
--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -6,4 +6,4 @@ channels:
 dependencies:
   - pip==9.0.1
   - wheel==0.29.0
-  - Sphinx==1.5.1
+  - sphinx==1.5.1


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/2 (hopefully 🍀)

Appears we were using `Sphinx` instead of `sphinx` in the `environment_doc.yml` file. Not sure if this was causing problems with RTD, but it does seem like the right place to start.