### PR TITLE
Drop unneeded rtd_requirements.txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,10 +299,11 @@ def run_apidoc(_):
     ] + ignore_paths
 
     try:
-        # Sphinx-1.7+
+        # Sphinx 1.7+
         from sphinx.ext import apidoc
         apidoc.main(argv)
     except ImportError:
+        # Sphinx 1.6 (and earlier)
         from sphinx import apidoc
         argv.insert(0, apidoc.__file__)
         apidoc.main(argv)

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,4 +1,0 @@
-mock
-pillow
-sphinx
-sphinx_rtd_theme


### PR DESCRIPTION
Accidentally snuck in with PR ( https://github.com/dask/dask-image/pull/5 ). Though it is actually unused. So drop `rtd_requirements.txt`.