### PR TITLE
Cleanup Python 3.4 remnants

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5, and 3.6. Check
+3. The pull request should work for Python 2.7, 3.5, and 3.6. Check
    https://travis-ci.org/dask/dask-image/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],


### PR DESCRIPTION
Already Python 3.4 is not planned for support here and is not being tested against. This removes the last few lingering references to Python 3.4.