### PR TITLE
Use Dask's standard doc stylesheet

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -311,3 +311,4 @@ def run_apidoc(_):
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
+    app.add_stylesheet("https://dask.pydata.org/en/latest/_static/style.css")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,7 +116,7 @@ pygments_style = 'default'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,7 @@ html_theme = 'default'
 # here, relative to this directory. They are copied after the builtin
 # static files, so a file named "default.css" will overwrite the builtin
 # "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - sphinx==1.7.5
+  - sphinx_rtd_theme==0.4.1
   - dask==0.13.0
   - numpy==1.11.3
   - pims==0.3.3


### PR DESCRIPTION
Switch from the Sphinx default stylesheet to Dask's standard stylesheet. Should make this fit in better with the other `dask-*` projects.

xref: https://github.com/dask/dask-image/issues/33#issuecomment-417490798