### PR TITLE
Require SciPy pre-1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "dask >=0.13.0",
     "numpy >=1.11.3",
-    "scipy >=0.18.1",
+    "scipy >=0.18.1,<1.0.0",
     "pims >=0.3.3",
 ]
 


### PR DESCRIPTION
It seems that SciPy 1.0.0+ causes some tests to fail. So go ahead and require SciPy to be pre-1.0.0 to ensure things don't break accidentally. Will need to revisit the cause of the failures separately and address them.