### PR TITLE
Consolidate README content in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,14 +33,3 @@ Distributed image processing
 
 * Free software: BSD 3-Clause
 * Documentation: https://dask-image.readthedocs.io.
-
-
-Features
---------
-
-* Support focuses on Dask Arrays.
-* Provides support for loading image files.
-* Implements commonly used N-D filters.
-* Includes a few N-D Fourier filters.
-* Provides some functions for working with N-D label images.
-* Supports a few N-D morphological operators.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,6 @@ Contents
 .. toctree::
    :maxdepth: 1
 
-   Readme <readme>
    installation
    api
    contributing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ Contents
    history
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,18 @@
 Image processing with Dask Arrays
 =================================
 
-Contents:
+Features
+--------
+
+* Support focuses on Dask Arrays.
+* Provides support for loading image files.
+* Implements commonly used N-D filters.
+* Includes a few N-D Fourier filters.
+* Provides some functions for working with N-D label images.
+* Supports a few N-D morphological operators.
+
+Contents
+--------
 
 .. toctree::
    :maxdepth: 1

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,0 @@
-.. include:: ../README.rst


### PR DESCRIPTION
Partially addresses https://github.com/dask/dask-image/issues/38

Moves the README content into the index page and drops the README from the docs.