### PR TITLE
Fix bug in test__norm_input_labels_index

### DIFF
--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -52,6 +52,10 @@ def test__norm_input_labels_index():
     assert isinstance(d_lbls_n, da.Array)
     assert isinstance(ind_n, da.Array)
 
+    assert d_n.shape == d.shape
+    assert d_lbls_n.shape == d_lbls.shape
+    assert ind_n.shape == ()
+
     dau.assert_eq(d_n, d)
     dau.assert_eq(d_lbls_n, d_lbls)
     dau.assert_eq(ind_n, np.array(1, dtype=int))

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -54,7 +54,7 @@ def test__norm_input_labels_index():
 
     dau.assert_eq(d_n, d)
     dau.assert_eq(d_lbls_n, d_lbls)
-    dau.assert_eq(ind_n, np.array([1], dtype=int))
+    dau.assert_eq(ind_n, np.array(1, dtype=int))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/dask/dask-image/issues/42

Appears this test assumed 0-D scalar arrays and 1-D singleton arrays were equivalent, which older versions of Dask let slide. However this was incorrect on our part. Fixes the test to check the scalar array correctly. Also adds explicit shape checks so that this gets caught on older versions of Dask.