### PR TITLE
Use conda-forge badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ dask-image
         :target: https://pypi.python.org/pypi/dask-image
         :alt: PyPI
 
-.. image:: https://anaconda.org/conda-forge/dask-image/badges/version.svg
+.. image:: https://img.shields.io/conda/vn/conda-forge/dask-image.svg
         :target: https://anaconda.org/conda-forge/dask-image
         :alt: conda-forge
 


### PR DESCRIPTION
Just to clarify that the Conda package is in conda-forge, use the conda-forge badge from Shields.io in the README.