### PR TITLE
Breakout common changes in fourier_gaussian

### DIFF
--- a/dask_image/ndfourier/__init__.py
+++ b/dask_image/ndfourier/__init__.py
@@ -65,8 +65,9 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1):
     )
 
     # Compute Fourier transformed Gaussian
+    scale = - (sigma ** 2) / 2
     gaussian = dask.array.exp(
-        - dask.array.tensordot(sigma ** 2, ang_freq_grid ** 2, axes=1) / 2
+        dask.array.tensordot(scale, ang_freq_grid ** 2, axes=1)
     )
 
     result = input * gaussian


### PR DESCRIPTION
In all cases `sigma` is squared, the result is divided by `2`, and the negative of the result taken. These can be factored out into a common change to just `sigma` that is reused in all of the other computations. Admittedly Dask is smart enough to capture the reused computation of `sigma` squared, but it is not a symbolic algebra library. So it won't be able to pick up on the other changes, but we can. This should simplify the resulting graph and make it easy to reuse some common changes to `sigma` before `tensordot` is computed over multiple arrays and these changes applied.