### PR TITLE
Ensure `J` is negated first in `fourier_shift`

### DIFF
--- a/dask_image/ndfourier/__init__.py
+++ b/dask_image/ndfourier/__init__.py
@@ -136,7 +136,7 @@ def fourier_shift(input, shift, n=-1, axis=-1):
 
     # Apply shift
     phase_shift = dask.array.exp(
-        - J * dask.array.tensordot(shift, ang_freq_grid, axes=1)
+        (-J) * dask.array.tensordot(shift, ang_freq_grid, axes=1)
     )
     result = input * phase_shift
 


### PR DESCRIPTION
Just to ensure that `J` is negated before graph construction and it is not rolled into graph construction, enforce the order of operations by treating `-J` as a quantity by itself. This way we can be sure it is already computed before graph construction begins and the scalar is merely inserted into the graph as a single node.