### PR TITLE
Perform `2 * pi` first in `_get_ang_freq_grid`

### DIFF
--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -59,7 +59,7 @@ def _get_ang_freq_grid(shape, chunks, dtype=float):
     pi = dtype(numpy.pi)
 
     freq_grid = _get_freq_grid(shape, chunks, dtype=dtype)
-    ang_freq_grid = 2 * pi * freq_grid
+    ang_freq_grid = (2 * pi) * freq_grid
 
     return ang_freq_grid
 


### PR DESCRIPTION
Just to ensure this scalar multiplication occurs before graph construction and is not added as operations in graph construction, enforce the order of operations by treating `2 * pi` as a quantity itself. This way we can be sure it is already computed before graph construction begins and the scalar is merely inserted into the graph as a single node.