### PR TITLE
Refactor Python 2/3 compatibility from imread

### DIFF
--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -15,6 +15,8 @@ import dask.delayed
 import numpy
 import pims
 
+from . import _pycompat
+
 
 def imread(fname, nframes=1):
     """
@@ -35,16 +37,6 @@ def imread(fname, nframes=1):
     array : dask.array.Array
         A Dask Array representing the contents of all image files.
     """
-
-    try:
-        irange = xrange
-    except NameError:
-        irange = range
-
-    try:
-        izip = itertools.izip
-    except AttributeError:
-        izip = zip
 
     if not isinstance(nframes, numbers.Integral):
         raise ValueError("`nframes` must be an integer.")
@@ -76,13 +68,13 @@ def imread(fname, nframes=1):
             return numpy.asanyarray(imgs[i])
 
     lower_iter, upper_iter = itertools.tee(itertools.chain(
-        irange(0, shape[0], nframes),
+        _pycompat.irange(0, shape[0], nframes),
         [shape[0]]
     ))
     next(upper_iter)
 
     a = []
-    for i, j in izip(lower_iter, upper_iter):
+    for i, j in _pycompat.izip(lower_iter, upper_iter):
         a.append(dask.array.from_delayed(
             dask.delayed(_read_frame)(fname, slice(i, j)),
             (j - i,) + shape[1:],

--- a/dask_image/imread/_pycompat.py
+++ b/dask_image/imread/_pycompat.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+try:
+    irange = xrange
+except NameError:
+    irange = range
+
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip

--- a/tests/test_dask_image/test_imread/test__pycompat.py
+++ b/tests/test_dask_image/test_imread/test__pycompat.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+from __future__ import absolute_import
+
+import dask_image.imread._pycompat
+
+
+def test_irange():
+    r = dask_image.imread._pycompat.irange(5)
+
+    assert not isinstance(r, list)
+
+    assert list(r) == [0, 1, 2, 3, 4]
+
+
+def test_izip():
+    r = dask_image.imread._pycompat.izip([1, 2], [3, 4, 5])
+
+    assert not isinstance(r, list)
+
+    assert list(r) == [(1, 3), (2, 4)]


### PR DESCRIPTION
Does some light refactoring of Python 2/3 compatibility content from `imread`.