### PR TITLE
Use shared Python 2/3 compatibility module

### DIFF
--- a/dask_image/_pycompat.py
+++ b/dask_image/_pycompat.py
@@ -6,6 +6,13 @@ except NameError:
     irange = range
 
 try:
-    from itertools import izip
+    from itertools import imap, izip
 except ImportError:
-    izip = zip
+    imap, izip = map, zip
+
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
+
+strlike = (bytes, unicode)

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -8,23 +8,7 @@ import re
 
 import numpy
 
-
-try:
-    from itertools import imap, izip
-except ImportError:
-    imap, izip = map, zip
-
-try:
-    irange = xrange
-except NameError:
-    irange = range
-
-try:
-    unicode
-except NameError:
-    unicode = str
-
-strlike = (bytes, unicode)
+from .._pycompat import imap, irange, izip, strlike, unicode
 
 
 def _get_docstring(func):

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -9,16 +9,7 @@ import numpy
 import dask.array
 
 from . import _compat
-
-try:
-    from itertools import imap
-except ImportError:
-    imap = map
-
-try:
-    irange = xrange
-except NameError:
-    irange = range
+from .._pycompat import imap, irange
 
 
 def _get_freq_grid(shape, chunks, dtype=float):

--- a/dask_image/ndmorph/_ops.py
+++ b/dask_image/ndmorph/_ops.py
@@ -6,12 +6,7 @@ import numpy
 import dask.array
 
 from . import _utils
-
-
-try:
-    irange = xrange
-except NameError:
-    irange = range
+from .._pycompat import irange
 
 
 def _where(condition, x, y):

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -11,23 +11,7 @@ import scipy.ndimage
 
 import dask.array
 
-
-try:
-    from itertools import imap, izip
-except ImportError:
-    imap, izip = map, zip
-
-try:
-    irange = xrange
-except NameError:
-    irange = range
-
-try:
-    unicode
-except NameError:
-    unicode = str
-
-strlike = (bytes, unicode)
+from .._pycompat import imap, irange, izip, strlike, unicode
 
 
 def _get_docstring(func):

--- a/tests/test_dask_image/test__pycompat.py
+++ b/tests/test_dask_image/test__pycompat.py
@@ -15,9 +15,31 @@ def test_irange():
     assert list(r) == [0, 1, 2, 3, 4]
 
 
+def test_imap():
+    r = dask_image._pycompat.imap(lambda e : e ** 2, [0, 1, 2, 3])
+
+    assert not isinstance(r, list)
+
+    assert list(r) == [0, 1, 4, 9]
+
+
 def test_izip():
     r = dask_image._pycompat.izip([1, 2], [3, 4, 5])
 
     assert not isinstance(r, list)
 
     assert list(r) == [(1, 3), (2, 4)]
+
+
+def test_strlike():
+    b = b"Hello World!"
+    u = u"Hello World!"
+
+    assert isinstance(b, dask_image._pycompat.strlike)
+    assert isinstance(u, dask_image._pycompat.strlike)
+
+
+def test_unicode():
+    u = u"Hello World!"
+
+    assert isinstance(u, dask_image._pycompat.unicode)


### PR DESCRIPTION
Refactors out some other buried Python 2/3 compatibility code and makes better use of the shared Python 2/3 compatibility module.