### PR TITLE
Cleanup freq_grid_i construction in _get_freq_grid

### DIFF
--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -29,8 +29,10 @@ def _get_freq_grid(shape, chunks, dtype=float):
         sl[i] = slice(None)
         sl = tuple(sl)
 
-        freq_grid_i = _compat._fftfreq(shape[i],
-                                       chunks=chunks[i]).astype(dtype)[sl]
+        freq_grid_i = _compat._fftfreq(shape[i], chunks=chunks[i])
+        freq_grid_i = freq_grid_i.astype(dtype)
+        freq_grid_i = freq_grid_i[sl]
+
         for j in itertools.chain(range(i), range(i + 1, ndim)):
             freq_grid_i = freq_grid_i.repeat(shape[j], axis=j)
 


### PR DESCRIPTION
This code looked a little weird and was bit packed together. Break it apart into steps so it is easier to see what is happening in `_get_freq_grid` to construct each `freq_grid_i` for each dimension.