### PR TITLE
Refactor utility module for imread

### DIFF
--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -16,6 +16,7 @@ import numpy
 import pims
 
 from .. import _pycompat
+from . import _utils
 
 
 def imread(fname, nframes=1):
@@ -63,10 +64,6 @@ def imread(fname, nframes=1):
             RuntimeWarning
         )
 
-    def _read_frame(fn, i):
-        with pims.open(fn) as imgs:
-            return numpy.asanyarray(imgs[i])
-
     lower_iter, upper_iter = itertools.tee(itertools.chain(
         _pycompat.irange(0, shape[0], nframes),
         [shape[0]]
@@ -76,7 +73,7 @@ def imread(fname, nframes=1):
     a = []
     for i, j in _pycompat.izip(lower_iter, upper_iter):
         a.append(dask.array.from_delayed(
-            dask.delayed(_read_frame)(fname, slice(i, j)),
+            dask.delayed(_utils._read_frame)(fname, slice(i, j)),
             (j - i,) + shape[1:],
             dtype
         ))

--- a/dask_image/imread/_utils.py
+++ b/dask_image/imread/_utils.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+
+__author__ = """John Kirkham"""
+__email__ = "kirkhamj@janelia.hhmi.org"

--- a/dask_image/imread/_utils.py
+++ b/dask_image/imread/_utils.py
@@ -3,3 +3,12 @@
 
 __author__ = """John Kirkham"""
 __email__ = "kirkhamj@janelia.hhmi.org"
+
+
+import numpy
+import pims
+
+
+def _read_frame(fn, i):
+    with pims.open(fn) as imgs:
+        return numpy.asanyarray(imgs[i])


### PR DESCRIPTION
Breaks out some functionality from `imread` into a utility module. In particular pulls out the closure `_read_frame`. As `_read_frame` doesn't really need to be a closure and it's a bit cheaper to pickle and serialize module level functions, go ahead and convert `_read_frame` into a utility function that `imread` uses. Makes the code a bit cleaner as well.