### PR TITLE
Force dtype of `prod` in `_ravel_shape_indices`

### DIFF
--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -57,8 +57,11 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
 
     indices = sum([
         dask.array.arange(
-            0, numpy.prod(dimensions[i:]), numpy.prod(dimensions[i + 1:]),
-            dtype=dtype, chunks=c
+            0,
+            numpy.prod(dimensions[i:], dtype=dtype),
+            numpy.prod(dimensions[i + 1:], dtype=dtype),
+            dtype=dtype,
+            chunks=c
         )[i * (None,) + (slice(None),) + (len(dimensions) - i - 1) * (None,)]
         for i, c in enumerate(chunks)
     ])


### PR DESCRIPTION
Make sure that NumPy's `prod` returns results that match the `dtype` of the `arange`. This is important as `prod` by default matches `float` if no other type is specified (e.g. it is given an empty sequence). While the `float` value will be handled correctly by NumPy, it's better to be explicit about the type `prod` should provide. That way if NumPy changes its behavior, we don't run into issues here.