### PR TITLE
Divide `sigma` by `-2`

### DIFF
--- a/dask_image/ndfourier/__init__.py
+++ b/dask_image/ndfourier/__init__.py
@@ -64,7 +64,7 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1):
     )
 
     # Compute Fourier transformed Gaussian
-    scale = - (sigma ** 2) / 2
+    scale = (sigma ** 2) / -2
     gaussian = dask.array.exp(
         dask.array.tensordot(scale, ang_freq_grid ** 2, axes=1)
     )


### PR DESCRIPTION
Instead of negating the result of `(sigma ** 2) / 2`, which may be a Dask Array meaning this would add more nodes to the graph, simply divide by `-2` instead. This ensures the sign still changes as intended, but this is included as part of the division step. Thus this avoids potentially adding more nodes to the Dask graph (assuming `sigma` is not concrete).