### PR TITLE
Refactor out `_unravel_index` function

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -382,13 +382,7 @@ def maximum_position(input, labels=None, index=None):
     if not max_1dpos_lbl.ndim:
         max_1dpos_lbl = max_1dpos_lbl[None]
 
-    max_pos_lbl = []
-    max_1dpos_lbl_rem = max_1dpos_lbl
-    for i in _pycompat.irange(input.ndim):
-        d = int(numpy.prod(input.shape[i + 1:]))
-        max_pos_lbl.append(max_1dpos_lbl_rem // d)
-        max_1dpos_lbl_rem %= d
-    max_pos_lbl = dask.array.stack(max_pos_lbl, axis=1)
+    max_pos_lbl = _utils._unravel_index(max_1dpos_lbl, input.shape)
 
     if index.shape == tuple():
         max_pos_lbl = dask.array.squeeze(max_pos_lbl)
@@ -537,13 +531,7 @@ def minimum_position(input, labels=None, index=None):
     if not min_1dpos_lbl.ndim:
         min_1dpos_lbl = min_1dpos_lbl[None]
 
-    min_pos_lbl = []
-    min_1dpos_lbl_rem = min_1dpos_lbl
-    for i in _pycompat.irange(input.ndim):
-        d = int(numpy.prod(input.shape[i + 1:]))
-        min_pos_lbl.append(min_1dpos_lbl_rem // d)
-        min_1dpos_lbl_rem %= d
-    min_pos_lbl = dask.array.stack(min_pos_lbl, axis=1)
+    min_pos_lbl = _utils._unravel_index(min_1dpos_lbl, input.shape)
 
     if index.shape == tuple():
         min_pos_lbl = dask.array.squeeze(min_pos_lbl)

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -152,3 +152,25 @@ def test___ravel_shape_indices(shape, chunks):
     )
 
     dau.assert_eq(d, a)
+
+
+@pytest.mark.parametrize(
+    "nindices, shape, order", [
+        (0, (15,), 'C'),
+        (1, (15,), 'C'),
+        (3, (15,), 'C'),
+        (3, (15,), 'F'),
+        (2, (15, 16), 'C'),
+        (2, (15, 16), 'F'),
+    ]
+)
+def test__unravel_index(nindices, shape, order):
+    findices = np.random.randint(np.prod(shape, dtype=int), size=nindices)
+    d_findices = da.from_array(findices, chunks=1)
+
+    indices = np.stack(np.unravel_index(findices, shape, order), axis=1)
+    d_indices = dask_image.ndmeasure._utils._unravel_index(
+        d_findices, shape, order
+    )
+
+    dau.assert_eq(d_indices, indices)


### PR DESCRIPTION
Adds a utility function `_unravel_index` to emulate NumPy's [`unravel_index`]( https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.unravel_index.html#numpy.unravel_index ) except for Dask Arrays. They are not 1-to-1 as we return a single Dask Array instead of `tuple`s of Dask Arrays. This change ends up being better suited for our use case. Include some tests for `_unravel_index`, which compare it NumPy's `unravel_index` with our modifications.

Rewrites `maximum_position` and `minimum_position` to use our `_unravel_index` function instead of rolling their own with Dask Arrays. This should create simpler, cleaner graphs for the Dask Arrays returned from `maximum_position` and `minimum_position`. Also should be easier for Dask to fuse tasks should it choose to (though we have effectively done some fusing ourselves). Not to mention gets rid of some code duplication in the process.