### PR TITLE
Use dask-sphinx-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,7 +116,7 @@ pygments_style = 'default'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'dask_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -311,4 +311,3 @@ def run_apidoc(_):
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
-    app.add_stylesheet("https://dask.pydata.org/en/latest/_static/style.css")

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - sphinx==1.7.5
-  - sphinx_rtd_theme==0.4.1
+  - dask-sphinx-theme==1.0.3
   - dask==0.16.1
   - numpy==1.11.3
   - pims==0.4.1


### PR DESCRIPTION
Switch over to Dask's new `dask-sphinx-theme` for handling documentation layout and styling. Should make it easier to keep the documentation style inline with other Dask projects.