### PR TITLE
Handle structured dtype in labeled_comprehension

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -277,7 +277,7 @@ def labeled_comprehension(input,
         input, labels, index
     )
     out_dtype = numpy.dtype(out_dtype)
-    default = numpy.array(default, dtype=out_dtype)[()]
+    default = numpy.array(default, dtype=out_dtype)
     pass_positions = bool(pass_positions)
 
     lbl_mtch = _utils._get_label_matches(labels, index)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -277,7 +277,7 @@ def labeled_comprehension(input,
         input, labels, index
     )
     out_dtype = numpy.dtype(out_dtype)
-    default = out_dtype.type(default)
+    default = numpy.array(default, dtype=out_dtype)[()]
     pass_positions = bool(pass_positions)
 
     lbl_mtch = _utils._get_label_matches(labels, index)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -277,7 +277,7 @@ def labeled_comprehension(input,
         input, labels, index
     )
     out_dtype = numpy.dtype(out_dtype)
-    default = numpy.array(default, dtype=out_dtype)
+    default = numpy.array([default], dtype=out_dtype)
     pass_positions = bool(pass_positions)
 
     lbl_mtch = _utils._get_label_matches(labels, index)
@@ -305,7 +305,7 @@ def labeled_comprehension(input,
         for j in index_ranges_i:
             result2[j] = dask.array.stack(result[j].tolist(), axis=0)
         result = result2
-    result = result[()]
+    result = result[()][..., 0]
 
     return result
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -146,9 +146,9 @@ def _labeled_comprehension_delayed(func,
 
     if a.size:
         if positions is None:
-            return out_dtype.type(func(a))
+            return numpy.array(func(a), dtype=out_dtype)[()]
         else:
-            return out_dtype.type(func(a, positions))
+            return numpy.array(func(a, positions), dtype=out_dtype)[()]
     else:
         return default
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -144,13 +144,17 @@ def _labeled_comprehension_delayed(func,
     computation should not occur.
     """
 
+    result = numpy.empty((1,), dtype=out_dtype)
+
     if a.size:
         if positions is None:
-            return numpy.array([func(a)], dtype=out_dtype)
+            result[0] = func(a)
         else:
-            return numpy.array([func(a, positions)], dtype=out_dtype)
+            result[0] = func(a, positions)
     else:
-        return default
+        result[0] = default[0]
+
+    return result
 
 
 def _labeled_comprehension_func(func,

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -146,9 +146,9 @@ def _labeled_comprehension_delayed(func,
 
     if a.size:
         if positions is None:
-            return numpy.array(func(a), dtype=out_dtype)[()]
+            return numpy.array(func(a), dtype=out_dtype)
         else:
-            return numpy.array(func(a, positions), dtype=out_dtype)[()]
+            return numpy.array(func(a, positions), dtype=out_dtype)
     else:
         return default
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -146,9 +146,9 @@ def _labeled_comprehension_delayed(func,
 
     if a.size:
         if positions is None:
-            return numpy.array(func(a), dtype=out_dtype)
+            return numpy.array([func(a)], dtype=out_dtype)
         else:
-            return numpy.array(func(a, positions), dtype=out_dtype)
+            return numpy.array([func(a, positions)], dtype=out_dtype)
     else:
         return default
 
@@ -166,6 +166,6 @@ def _labeled_comprehension_func(func,
 
     return dask.array.from_delayed(
         _labeled_comprehension_delayed(func, out_dtype, default, a, positions),
-        tuple(),
+        (1,),
         out_dtype
     )


### PR DESCRIPTION
Update our `labeled_comprehension` implementation so that it can handle a structured array-based scalar value. This is useful for functions that need to return a few related values from each computation (e.g. a specific value and its position). Also useful for optimizing `extrema` using a specialized kernel function, which returns multiple values from each block.