### PR TITLE
Ensure `labeled_comprehension`'s `default` is 1D

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -302,8 +302,12 @@ def labeled_comprehension(input,
     input, labels, index = _utils._norm_input_labels_index(
         input, labels, index
     )
+
     out_dtype = numpy.dtype(out_dtype)
-    default = numpy.array([default], dtype=out_dtype)
+
+    default_1d = numpy.empty((1,), dtype=out_dtype)
+    default_1d[0] = default
+
     pass_positions = bool(pass_positions)
 
     lbl_mtch = _utils._get_label_matches(labels, index)
@@ -322,7 +326,7 @@ def labeled_comprehension(input,
         lbl_mtch_i = lbl_mtch[i]
         args_lbl_mtch_i = tuple(e[lbl_mtch_i] for e in args)
         result[i] = _utils._labeled_comprehension_func(
-            func, out_dtype, default, *args_lbl_mtch_i
+            func, out_dtype, default_1d, *args_lbl_mtch_i
         )
 
     for i in _pycompat.irange(result.ndim - 1, -1, -1):


### PR DESCRIPTION
Create an `empty` 1-D scalar array of the expected return type of the user function. Then store this `default` value into the 1-D scalar array. This has the advantage of raising a `ValueError` if the `default` value cannot be coerced into a scalar of the appropriate type and stored into this array. It also handles some situations better like having a 1-D scalar array provided as the `default` value by ensuring the result remains 1-D.