### PR TITLE
Rewrite `histogram` to use `labeled_comprehension`

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -7,6 +7,7 @@ __author__ = """John Kirkham"""
 __email__ = "kirkhamj@janelia.hhmi.org"
 
 
+import functools
 import itertools
 from warnings import warn
 
@@ -184,16 +185,8 @@ def histogram(input,
     max = int(max)
     bins = int(bins)
 
-    lbl_mtch = _utils._get_label_matches(labels, index)
-
-    index_ranges = [_pycompat.irange(e) for e in index.shape]
-
-    result = numpy.empty(index.shape, dtype=object)
-    for i in itertools.product(*index_ranges):
-        result[i] = _utils._histogram(
-            input[lbl_mtch[i]], min, max, bins
-        )
-    result = result[()]
+    func = functools.partial(_utils._histogram, min=min, max=max, bins=bins)
+    result = labeled_comprehension(input, labels, index, func, object, None)
 
     return result
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -152,7 +152,6 @@ def _extrema(a, positions):
     return result[()]
 
 
-@dask.delayed
 def _histogram(input,
                min,
                max,
@@ -163,10 +162,7 @@ def _histogram(input,
     Also reformats the arguments.
     """
 
-    if input.size:
-        return numpy.histogram(input, bins, (min, max))[0]
-    else:
-        return None
+    return numpy.histogram(input, bins, (min, max))[0]
 
 
 @dask.delayed


### PR DESCRIPTION
To simplify the `histogram` implementation a bit, rewrite it using `labeled_comprehension`. Make use of `functools.partial` to bind arguments to `histogram` so that it can be used with `labeled_comprehension`. Also simplify the internal `_histogram` function into a basic kernel function following these changes. Set the return type of `labeled_comprehension` as `object` to match that of what `histogram` used prior.