### PR TITLE
Adjust `extrema`'s internal structured type handling

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -109,9 +109,10 @@ def extrema(input, labels=None, index=None):
 
     default_1d = numpy.zeros((1,), dtype=out_dtype)
 
+    func = functools.partial(_utils._extrema, dtype=out_dtype)
     extrema_lbl = labeled_comprehension(
         input, labels, index,
-        _utils._extrema, out_dtype, default_1d[0], pass_positions=True
+        func, out_dtype, default_1d[0], pass_positions=True
     )
 
     extrema_lbl = collections.OrderedDict([

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -100,8 +100,8 @@ def extrema(input, labels=None, index=None):
 
     out_dtype = numpy.dtype([
         ("min_val", input.dtype),
-        ("min_pos", numpy.dtype(numpy.int)),
         ("max_val", input.dtype),
+        ("min_pos", numpy.dtype(numpy.int)),
         ("max_pos", numpy.dtype(numpy.int))
     ])
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -7,6 +7,7 @@ __author__ = """John Kirkham"""
 __email__ = "kirkhamj@janelia.hhmi.org"
 
 
+import collections
 import functools
 import itertools
 from warnings import warn
@@ -98,12 +99,13 @@ def extrema(input, labels=None, index=None):
         input, labels, index
     )
 
-    out_dtype = numpy.dtype([
+    type_mapping = collections.OrderedDict([
         ("min_val", input.dtype),
         ("max_val", input.dtype),
         ("min_pos", numpy.dtype(numpy.int)),
         ("max_pos", numpy.dtype(numpy.int))
     ])
+    out_dtype = numpy.dtype(list(type_mapping.items()))
 
     default_1d = numpy.zeros((1,), dtype=out_dtype)
 
@@ -112,7 +114,9 @@ def extrema(input, labels=None, index=None):
         _utils._extrema, out_dtype, default_1d[0], pass_positions=True
     )
 
-    extrema_lbl = {k: extrema_lbl[k] for k in extrema_lbl.dtype.names}
+    extrema_lbl = collections.OrderedDict([
+        (k, extrema_lbl[k]) for k in type_mapping.keys()
+    ])
 
     for pos_key in ["min_pos", "max_pos"]:
         pos_1d = extrema_lbl[pos_key]
@@ -130,12 +134,7 @@ def extrema(input, labels=None, index=None):
 
         extrema_lbl[pos_key] = pos_nd
 
-    result = (
-        extrema_lbl["min_val"],
-        extrema_lbl["max_val"],
-        extrema_lbl["min_pos"],
-        extrema_lbl["max_pos"]
-    )
+    result = tuple(extrema_lbl.values())
 
     return result
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -104,11 +104,12 @@ def extrema(input, labels=None, index=None):
         ("max_val", input.dtype),
         ("max_pos", numpy.dtype(numpy.int))
     ])
-    default = numpy.zeros((), out_dtype)[()]
+
+    default_1d = numpy.zeros((1,), dtype=out_dtype)
 
     extrema_lbl = labeled_comprehension(
         input, labels, index,
-        _utils._extrema, out_dtype, default, pass_positions=True
+        _utils._extrema, out_dtype, default_1d[0], pass_positions=True
     )
 
     extrema_lbl = {k: extrema_lbl[k] for k in extrema_lbl.dtype.names}

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -100,9 +100,9 @@ def extrema(input, labels=None, index=None):
 
     out_dtype = numpy.dtype([
         ("min_val", input.dtype),
-        ("min_pos", numpy.int),
+        ("min_pos", numpy.dtype(numpy.int)),
         ("max_val", input.dtype),
-        ("max_pos", numpy.int)
+        ("max_pos", numpy.dtype(numpy.int))
     ])
     default = numpy.zeros((), out_dtype)[()]
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -135,8 +135,8 @@ def _extrema(a, positions):
 
     dtype = numpy.dtype([
         ("min_val", a.dtype),
-        ("min_pos", positions.dtype),
         ("max_val", a.dtype),
+        ("min_pos", positions.dtype),
         ("max_pos", positions.dtype)
     ])
     result = numpy.empty((1,), dtype=dtype)

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -128,17 +128,11 @@ def _argmin(a, positions):
     return positions[numpy.argmin(a)]
 
 
-def _extrema(a, positions):
+def _extrema(a, positions, dtype):
     """
     Find minimum and maximum as well as positions for both.
     """
 
-    dtype = numpy.dtype([
-        ("min_val", a.dtype),
-        ("max_val", a.dtype),
-        ("min_pos", positions.dtype),
-        ("max_pos", positions.dtype)
-    ])
     result = numpy.empty((1,), dtype=dtype)
 
     int_min_pos = numpy.argmin(a)

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -139,7 +139,7 @@ def _extrema(a, positions):
         ("max_val", a.dtype),
         ("max_pos", positions.dtype)
     ])
-    result = numpy.empty((), dtype=dtype)
+    result = numpy.empty((1,), dtype=dtype)
 
     int_min_pos = numpy.argmin(a)
     result["min_val"] = a[int_min_pos]
@@ -149,7 +149,7 @@ def _extrema(a, positions):
     result["max_val"] = a[int_max_pos]
     result["max_pos"] = positions[int_max_pos]
 
-    return result[()]
+    return result[0]
 
 
 def _histogram(input,


### PR DESCRIPTION
Makes some adjust to `extrema`'s internal structured type handling. Namely orders the fields to match the result's order. Also makes use of `OrderedDict`s to ensure that this ordering of fields is used both in the `dtype`'s construction and later steps used to split apart the different results after `extrema`'s kernel has been run by the `labeled_comprehension` call. Additionally binds the `dtype` to the `extrema` kernel function before calling it to drop code reconstructing the `dtype` within the kernel. Simplifies the surrounding code a bit.