### PR TITLE
Rewrite `center_of_mass` using `labeled_comprehension`

### DIFF
--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
+from __future__ import division
+
 import operator
 import warnings
 
@@ -126,6 +128,26 @@ def _argmin(a, positions):
     """
 
     return positions[numpy.argmin(a)]
+
+
+def _center_of_mass(a, positions, shape, dtype):
+    """
+    Find the center of mass for each ROI.
+
+    Package the result in a structured array with each field as an index.
+    """
+
+    result = numpy.empty((1,), dtype=dtype)
+
+    positions_nd = numpy.unravel_index(positions, shape)
+    a_sum = numpy.sum(a)
+
+    a_wt_i = numpy.empty_like(a)
+    for i, pos_nd_i in enumerate(positions_nd):
+        a_wt_sum_i = numpy.multiply(a, pos_nd_i, out=a_wt_i).sum()
+        result[("%i" % i)] = a_wt_sum_i / a_sum
+
+    return result[0]
 
 
 def _extrema(a, positions, dtype):


### PR DESCRIPTION
Adds a custom kernel for `center_of_mass` to use with `labeled_comprehension` and rewrites `center_of_mass` using that kernel. Using a little trickier to handle the fact that `center_of_mass` returns a 1-D array instead of a scalar by packing this into a structured array instead. Names the structured array fields using `bytes` containing each index. Pulls this result apart and repacks it in the expected form before returning it to the user.

This rewrite of `center_of_mass` significantly simplifies the Dask graph, notably improves performance, and cleans up the code a bit. All of this thanks to the custom kernel used by `center_of_mass`, which now handles all computations related to the center of mass for each ROI using only the data needed and avoiding computations on data that would be tossed otherwise. Should be a nice performance bump for users as well as helping speedup the test suite a bit.