### PR TITLE
Use 1-D structured array fields for position-based kernels in `ndmeasure`

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -91,32 +91,28 @@ def extrema(input, labels=None, index=None):
         input, labels, index
     )
 
-    type_mapping = collections.OrderedDict([
+    out_dtype = numpy.dtype([
         ("min_val", input.dtype),
         ("max_val", input.dtype),
-        ("min_pos", numpy.dtype(numpy.int)),
-        ("max_pos", numpy.dtype(numpy.int))
+        ("min_pos", numpy.dtype(numpy.int), input.ndim),
+        ("max_pos", numpy.dtype(numpy.int), input.ndim)
     ])
-    out_dtype = numpy.dtype(list(type_mapping.items()))
-
     default_1d = numpy.zeros((1,), dtype=out_dtype)
 
-    func = functools.partial(_utils._extrema, dtype=out_dtype)
+    func = functools.partial(
+        _utils._extrema, shape=input.shape, dtype=out_dtype
+    )
     extrema_lbl = labeled_comprehension(
         input, labels, index,
         func, out_dtype, default_1d[0], pass_positions=True
     )
-
     extrema_lbl = collections.OrderedDict([
-        (k, extrema_lbl[k]) for k in type_mapping.keys()
+        (k, extrema_lbl[k])
+        for k in ["min_val", "max_val", "min_pos", "max_pos"]
     ])
 
     for pos_key in ["min_pos", "max_pos"]:
-        pos_1d = extrema_lbl[pos_key]
-        if not pos_1d.ndim:
-            pos_1d = pos_1d[None]
-
-        pos_nd = _utils._unravel_index(pos_1d, input.shape)
+        pos_nd = extrema_lbl[pos_key]
 
         if index.ndim == 0:
             pos_nd = dask.array.squeeze(pos_nd)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -391,14 +391,17 @@ def maximum_position(input, labels=None, index=None):
     if index.shape:
         index = index.flatten()
 
-    max_1dpos_lbl = labeled_comprehension(
-        input, labels, index, _utils._argmax, int, 0, pass_positions=True
+    out_dtype = numpy.dtype([("pos", int, (input.ndim,))])
+    default_1d = numpy.zeros((1,), dtype=out_dtype)
+
+    func = functools.partial(
+        _utils._argmax, shape=input.shape, dtype=out_dtype
     )
-
-    if not max_1dpos_lbl.ndim:
-        max_1dpos_lbl = max_1dpos_lbl[None]
-
-    max_pos_lbl = _utils._unravel_index(max_1dpos_lbl, input.shape)
+    max_pos_lbl = labeled_comprehension(
+        input, labels, index,
+        func, out_dtype, default_1d[0], pass_positions=True
+    )
+    max_pos_lbl = max_pos_lbl["pos"]
 
     if index.shape == tuple():
         max_pos_lbl = dask.array.squeeze(max_pos_lbl)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -50,11 +50,7 @@ def center_of_mass(input, labels=None, index=None):
     # This only matters if index is some array.
     index = index.T
 
-    type_mapping = collections.OrderedDict([
-        (("%i" % i), input.dtype) for i in _pycompat.irange(input.ndim)
-    ])
-    out_dtype = numpy.dtype(list(type_mapping.items()))
-
+    out_dtype = numpy.dtype([("com", input.dtype, (input.ndim,))])
     default_1d = numpy.full((1,), numpy.nan, dtype=out_dtype)
 
     func = functools.partial(
@@ -64,8 +60,7 @@ def center_of_mass(input, labels=None, index=None):
         input, labels, index,
         func, out_dtype, default_1d[0], pass_positions=True
     )
-
-    com_lbl = dask.array.stack([com_lbl[k] for k in type_mapping], axis=-1)
+    com_lbl = com_lbl["com"]
 
     return com_lbl
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -540,14 +540,17 @@ def minimum_position(input, labels=None, index=None):
     if index.shape:
         index = index.flatten()
 
-    min_1dpos_lbl = labeled_comprehension(
-        input, labels, index, _utils._argmin, int, 0, pass_positions=True
+    out_dtype = numpy.dtype([("pos", int, (input.ndim,))])
+    default_1d = numpy.zeros((1,), dtype=out_dtype)
+
+    func = functools.partial(
+        _utils._argmin, shape=input.shape, dtype=out_dtype
     )
-
-    if not min_1dpos_lbl.ndim:
-        min_1dpos_lbl = min_1dpos_lbl[None]
-
-    min_pos_lbl = _utils._unravel_index(min_1dpos_lbl, input.shape)
+    min_pos_lbl = labeled_comprehension(
+        input, labels, index,
+        func, out_dtype, default_1d[0], pass_positions=True
+    )
+    min_pos_lbl = min_pos_lbl["pos"]
 
     if index.shape == tuple():
         min_pos_lbl = dask.array.squeeze(min_pos_lbl)

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -128,12 +128,18 @@ def _argmax(a, positions, shape, dtype):
     return result[0]
 
 
-def _argmin(a, positions):
+def _argmin(a, positions, shape, dtype):
     """
     Find original array position corresponding to the minimum.
     """
 
-    return positions[numpy.argmin(a)]
+    result = numpy.empty((1,), dtype=dtype)
+
+    pos_nd = numpy.unravel_index(positions[numpy.argmin(a)], shape)
+    for i, pos_nd_i in enumerate(pos_nd):
+        result["pos"][0, i] = pos_nd_i
+
+    return result[0]
 
 
 def _center_of_mass(a, positions, shape, dtype):

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -160,7 +160,7 @@ def _center_of_mass(a, positions, shape, dtype):
     return result[0]
 
 
-def _extrema(a, positions, dtype):
+def _extrema(a, positions, shape, dtype):
     """
     Find minimum and maximum as well as positions for both.
     """
@@ -168,12 +168,16 @@ def _extrema(a, positions, dtype):
     result = numpy.empty((1,), dtype=dtype)
 
     int_min_pos = numpy.argmin(a)
-    result["min_val"] = a[int_min_pos]
-    result["min_pos"] = positions[int_min_pos]
-
     int_max_pos = numpy.argmax(a)
+
+    result["min_val"] = a[int_min_pos]
     result["max_val"] = a[int_max_pos]
-    result["max_pos"] = positions[int_max_pos]
+
+    min_pos_nd = numpy.unravel_index(positions[int_min_pos], shape)
+    max_pos_nd = numpy.unravel_index(positions[int_max_pos], shape)
+    for i in range(len(shape)):
+        result["min_pos"][0, i] = min_pos_nd[i]
+        result["max_pos"][0, i] = max_pos_nd[i]
 
     return result[0]
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -133,8 +133,6 @@ def _argmin(a, positions):
 def _center_of_mass(a, positions, shape, dtype):
     """
     Find the center of mass for each ROI.
-
-    Package the result in a structured array with each field as an index.
     """
 
     result = numpy.empty((1,), dtype=dtype)
@@ -145,7 +143,7 @@ def _center_of_mass(a, positions, shape, dtype):
     a_wt_i = numpy.empty_like(a)
     for i, pos_nd_i in enumerate(positions_nd):
         a_wt_sum_i = numpy.multiply(a, pos_nd_i, out=a_wt_i).sum()
-        result[("%i" % i)] = a_wt_sum_i / a_sum
+        result["com"][0, i] = a_wt_sum_i / a_sum
 
     return result[0]
 

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -114,12 +114,18 @@ def _unravel_index(indices, dims, order='C'):
     return unraveled_indices
 
 
-def _argmax(a, positions):
+def _argmax(a, positions, shape, dtype):
     """
     Find original array position corresponding to the maximum.
     """
 
-    return positions[numpy.argmax(a)]
+    result = numpy.empty((1,), dtype=dtype)
+
+    pos_nd = numpy.unravel_index(positions[numpy.argmax(a)], shape)
+    for i, pos_nd_i in enumerate(pos_nd):
+        result["pos"][0, i] = pos_nd_i
+
+    return result[0]
 
 
 def _argmin(a, positions):

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -85,35 +85,6 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
     return indices
 
 
-def _unravel_index_kernel(indices, func_kwargs):
-    nd_indices = numpy.unravel_index(indices, **func_kwargs)
-    nd_indices = numpy.stack(nd_indices, axis=indices.ndim)
-    return nd_indices
-
-
-def _unravel_index(indices, dims, order='C'):
-    """
-    Unravels the indices like NumPy's ``unravel_index``.
-
-    Uses NumPy's ``unravel_index`` on Dask Array blocks.
-    """
-
-    if dims and indices.size:
-        unraveled_indices = indices.map_blocks(
-            _unravel_index_kernel,
-            dtype=numpy.intp,
-            chunks=indices.chunks + ((len(dims),),),
-            new_axis=indices.ndim,
-            func_kwargs={"dims": dims, "order": order}
-        )
-    else:
-        unraveled_indices = dask.array.empty(
-            (0, len(dims)), dtype=numpy.intp, chunks=1
-        )
-
-    return unraveled_indices
-
-
 def _argmax(a, positions, shape, dtype):
     """
     Find original array position corresponding to the maximum.

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -152,25 +152,3 @@ def test___ravel_shape_indices(shape, chunks):
     )
 
     dau.assert_eq(d, a)
-
-
-@pytest.mark.parametrize(
-    "nindices, shape, order", [
-        (0, (15,), 'C'),
-        (1, (15,), 'C'),
-        (3, (15,), 'C'),
-        (3, (15,), 'F'),
-        (2, (15, 16), 'C'),
-        (2, (15, 16), 'F'),
-    ]
-)
-def test__unravel_index(nindices, shape, order):
-    findices = np.random.randint(np.prod(shape, dtype=int), size=nindices)
-    d_findices = da.from_array(findices, chunks=1)
-
-    indices = np.stack(np.unravel_index(findices, shape, order), axis=1)
-    d_indices = dask_image.ndmeasure._utils._unravel_index(
-        d_findices, shape, order
-    )
-
-    dau.assert_eq(d_indices, indices)


### PR DESCRIPTION
Rewrites position-based kernels to leverage 1-D structured array fields to return unraveled coordinate values. This simplifies the Dask graphs of these functions by dropping steps that performed the unraveling or repacking of these results. Should aid performance by handling more computations within a single kernel where it is easily solved as well as avoiding stacking arrays. Drops the `_unravel_index` utility function and its tests as a consequence of this change since it is no longer needed.