### PR TITLE
Construct separate label masks in `labeled_comprehension`

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -6,6 +6,7 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 
 import collections
 import functools
+import operator
 from warnings import warn
 
 import numpy
@@ -291,7 +292,10 @@ def labeled_comprehension(input,
 
     pass_positions = bool(pass_positions)
 
-    lbl_mtch = _utils._get_label_matches(labels, index)
+    lbl_mtch = operator.eq(
+        labels[index.ndim * (None,) + (Ellipsis,)],
+        index[(Ellipsis,) + labels.ndim * (None,)]
+    )
 
     args = (input,)
     if pass_positions:

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -6,7 +6,6 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 
 import collections
 import functools
-import operator
 from warnings import warn
 
 import numpy
@@ -292,11 +291,6 @@ def labeled_comprehension(input,
 
     pass_positions = bool(pass_positions)
 
-    lbl_mtch = operator.eq(
-        labels[index.ndim * (None,) + (Ellipsis,)],
-        index[(Ellipsis,) + labels.ndim * (None,)]
-    )
-
     args = (input,)
     if pass_positions:
         positions = _utils._ravel_shape_indices(
@@ -306,7 +300,7 @@ def labeled_comprehension(input,
 
     result = numpy.empty(index.shape, dtype=object)
     for i in numpy.ndindex(index.shape):
-        lbl_mtch_i = lbl_mtch[i]
+        lbl_mtch_i = (labels == index[i])
         args_lbl_mtch_i = tuple(e[lbl_mtch_i] for e in args)
         result[i] = _utils._labeled_comprehension_func(
             func, out_dtype, default_1d, *args_lbl_mtch_i

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -43,15 +43,6 @@ def _norm_input_labels_index(input, labels=None, index=None):
     return (input, labels, index)
 
 
-def _get_label_matches(labels, index):
-    lbl_mtch = operator.eq(
-        index[(Ellipsis,) + labels.ndim * (None,)],
-        labels[index.ndim * (None,)]
-    )
-
-    return lbl_mtch
-
-
 def _ravel_shape_indices_kernel(*args):
     args2 = tuple(
         a[i * (None,) + (slice(None),) + (len(args) - i - 1) * (None,)]

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -99,45 +99,6 @@ def test__norm_input_labels_index_warn(shape, chunks, ind):
 
 
 @pytest.mark.parametrize(
-    "shape, chunks, ind", [
-        ((15, 16), (4, 5), 0),
-        ((15, 16), (4, 5), 1),
-        ((15, 16), (4, 5), [1]),
-        ((15, 16), (4, 5), [1, 2]),
-        ((15, 16), (4, 5), [1, 100]),
-        ((15, 16), (4, 5), [[1, 2, 3, 4]]),
-        ((15, 16), (4, 5), [[1, 2], [3, 4]]),
-        ((15, 16), (4, 5), [[[1], [2], [3], [4]]]),
-    ]
-)
-def test__get_label_matches(shape, chunks, ind):
-    a = np.random.random(shape)
-    d = da.from_array(a, chunks=chunks)
-
-    lbls = np.zeros(a.shape, dtype=np.int64)
-    lbls += (
-        (a < 0.5).astype(lbls.dtype) +
-        (a < 0.25).astype(lbls.dtype) +
-        (a < 0.125).astype(lbls.dtype) +
-        (a < 0.0625).astype(lbls.dtype)
-    )
-    d_lbls = da.from_array(lbls, chunks=d.chunks)
-
-    ind = np.array(ind)
-    d_ind = da.from_array(ind, chunks=1)
-
-    lbl_mtch = operator.eq(
-        ind[(Ellipsis,) + lbls.ndim * (None,)],
-        lbls[ind.ndim * (None,)]
-    )
-    d_lbl_mtch = dask_image.ndmeasure._utils._get_label_matches(d_lbls, d_ind)
-
-    assert issubclass(d_lbl_mtch.dtype.type, np.bool8)
-
-    dau.assert_eq(d_lbl_mtch, lbl_mtch)
-
-
-@pytest.mark.parametrize(
     "shape, chunks", [
         ((15,), (4,)),
         ((15, 16), (4, 5)),


### PR DESCRIPTION
Instead of constructing an array of masks of where each label can be found, simply construct each label mask independently right before it is used. This way the computation of the user defined function in `labeled_comprehension` can easily happen independently for each label. Dask can usually optimize a graph like this a bit better than the former construction. Performance seems to improve here as well. Drops some code that is made unnecessary as a consequence.