### PR TITLE
Use `full` to construct 1-D NumPy array

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -286,7 +286,6 @@ def labeled_comprehension(input,
     )
 
     out_dtype = numpy.dtype(out_dtype)
-
     default_1d = numpy.full((1,), default, dtype=out_dtype)
 
     pass_positions = bool(pass_positions)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -287,8 +287,7 @@ def labeled_comprehension(input,
 
     out_dtype = numpy.dtype(out_dtype)
 
-    default_1d = numpy.empty((1,), dtype=out_dtype)
-    default_1d[0] = default
+    default_1d = numpy.full((1,), default, dtype=out_dtype)
 
     pass_positions = bool(pass_positions)
 


### PR DESCRIPTION
In `labeled_comprehension`, instead of using `empty` and assigning `default_1d` the `default` value, simply use `numpy.full` to construct the `default_1d` array with the `default` value.