### PR TITLE
Update installation instructions so conda is the preferred method

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,15 +12,28 @@ To install dask-image, run this command in your terminal:
 
 .. code-block:: console
 
+    $ conda install -c conda-forge dask-image
+
+This is the preferred method to install dask-image, as it will always install
+the most recent stable release.
+
+If you don't have `conda`_ installed, you can download and install it with the
+`Anaconda distribution here`_.
+
+Alternatively, you can install dask-image with pip:
+
+.. code-block:: console
+
     $ pip install dask-image
 
-This is the preferred method to install dask-image, as it will always install the most recent stable release.
+If you don't have `pip`_ installed, this `Python installation guide`_
+can guide you through the process.
 
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
-
+.. _conda: https://conda.io/en/latest/
+.. _Anaconda distribution here: https://www.anaconda.com/distribution/
 .. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
+.. _Python installation guide:
+http://docs.python-guide.org/en/latest/starting/installation/
 
 
 From sources


### PR DESCRIPTION
Update installation instructions so conda is the preferred method instead of pip.

