### PR TITLE
Sort Python 3.7 requirements

### DIFF
--- a/.appveyor_support/environments/tst_py37.yml
+++ b/.appveyor_support/environments/tst_py37.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.7.*
+  - pip=19.0.1
+  - wheel=0.32.3
   - coverage=4.5.2
+  - pytest=4.2.0
   - dask=1.1.1
   - numpy=1.15.4
-  - pims=0.4.1
-  - pip=19.0.1
-  - pytest=4.2.0
-  - scikit-image=0.14.2
   - scipy=1.2.0
+  - scikit-image=0.14.2
+  - pims=0.4.1
   - slicerator=0.9.8
-  - wheel=0.32.3
   - pip:
     - slicerator==0.9.8

--- a/.circleci/environments/tst_py37.yml
+++ b/.circleci/environments/tst_py37.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.7.*
+  - pip=19.0.1
+  - wheel=0.32.3
   - coverage=4.5.2
+  - pytest=4.2.0
   - dask=1.1.1
   - numpy=1.16.0
-  - pims=0.4.1
-  - pip=19.0.1
-  - pytest=4.2.0
-  - scikit-image=0.14.2
   - scipy=1.2.0
+  - scikit-image=0.14.2
+  - pims=0.4.1
   - slicerator=0.9.8
-  - wheel=0.32.3
   - pip:
     - slicerator==0.9.8

--- a/.travis_support/environments/tst_py37.yml
+++ b/.travis_support/environments/tst_py37.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.7.*
+  - pip=19.0.1
+  - wheel=0.32.3
   - coverage=4.5.2
+  - pytest=4.2.0
   - dask=1.1.1
   - numpy=1.16.0
-  - pims=0.4.1
-  - pip=19.0.1
-  - pytest=4.2.0
-  - scikit-image=0.14.2
   - scipy=1.2.0
+  - scikit-image=0.14.2
+  - pims=0.4.1
   - slicerator=0.9.8
-  - wheel=0.32.3
   - pip:
     - slicerator==0.9.8


### PR DESCRIPTION
Align the order of Python 3.7 requirements to the order used in the other environment files to make it easier to identify differences between the Python versions.