### PR TITLE
Use double equals for exact package versions

### DIFF
--- a/.appveyor_support/environments/tst_py27.yml
+++ b/.appveyor_support/environments/tst_py27.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.14.2
+  - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.appveyor_support/environments/tst_py35.yml
+++ b/.appveyor_support/environments/tst_py35.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.13.1
+  - scikit-image==0.13.1
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.appveyor_support/environments/tst_py36.yml
+++ b/.appveyor_support/environments/tst_py36.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.14.2
+  - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.appveyor_support/environments/tst_py37.yml
+++ b/.appveyor_support/environments/tst_py37.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.7.*
-  - pip=19.0.1
-  - wheel=0.32.3
-  - coverage=4.5.2
-  - pytest=4.2.0
-  - dask=1.1.1
-  - numpy=1.15.4
-  - scipy=1.2.0
-  - scikit-image=0.14.2
-  - pims=0.4.1
-  - slicerator=0.9.8
+  - pip==19.0.1
+  - wheel==0.32.3
+  - coverage==4.5.2
+  - pytest==4.2.0
+  - dask==1.1.1
+  - numpy==1.15.4
+  - scipy==1.2.0
+  - scikit-image==0.14.2
+  - pims==0.4.1
+  - slicerator==0.9.8
   - pip:
     - slicerator==0.9.8

--- a/.circleci/environments/tst_py27.yml
+++ b/.circleci/environments/tst_py27.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.14.2
+  - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.circleci/environments/tst_py35.yml
+++ b/.circleci/environments/tst_py35.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.13.1
+  - scikit-image==0.13.1
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.circleci/environments/tst_py36.yml
+++ b/.circleci/environments/tst_py36.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.14.2
+  - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.circleci/environments/tst_py37.yml
+++ b/.circleci/environments/tst_py37.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.7.*
-  - pip=19.0.1
-  - wheel=0.32.3
-  - coverage=4.5.2
-  - pytest=4.2.0
-  - dask=1.1.1
-  - numpy=1.16.0
-  - scipy=1.2.0
-  - scikit-image=0.14.2
-  - pims=0.4.1
-  - slicerator=0.9.8
+  - pip==19.0.1
+  - wheel==0.32.3
+  - coverage==4.5.2
+  - pytest==4.2.0
+  - dask==1.1.1
+  - numpy==1.16.0
+  - scipy==1.2.0
+  - scikit-image==0.14.2
+  - pims==0.4.1
+  - slicerator==0.9.8
   - pip:
     - slicerator==0.9.8

--- a/.travis_support/environments/tst_py27.yml
+++ b/.travis_support/environments/tst_py27.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.14.2
+  - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.travis_support/environments/tst_py35.yml
+++ b/.travis_support/environments/tst_py35.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.13.1
+  - scikit-image==0.13.1
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.travis_support/environments/tst_py36.yml
+++ b/.travis_support/environments/tst_py36.yml
@@ -12,7 +12,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image=0.14.2
+  - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.travis_support/environments/tst_py37.yml
+++ b/.travis_support/environments/tst_py37.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.7.*
-  - pip=19.0.1
-  - wheel=0.32.3
-  - coverage=4.5.2
-  - pytest=4.2.0
-  - dask=1.1.1
-  - numpy=1.16.0
-  - scipy=1.2.0
-  - scikit-image=0.14.2
-  - pims=0.4.1
-  - slicerator=0.9.8
+  - pip==19.0.1
+  - wheel==0.32.3
+  - coverage==4.5.2
+  - pytest==4.2.0
+  - dask==1.1.1
+  - numpy==1.16.0
+  - scipy==1.2.0
+  - scikit-image==0.14.2
+  - pims==0.4.1
+  - slicerator==0.9.8
   - pip:
     - slicerator==0.9.8


### PR DESCRIPTION
To standardize the environment files a bit, make sure that everything uses `==`s when pinning exact package versions.