### PR TITLE
Use flake8

### DIFF
--- a/.appveyor_support/environments/tst_py27.yml
+++ b/.appveyor_support/environments/tst_py27.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.7.2
   - pytest==3.8.2
+  - pytest-flake8==1.0.4
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.appveyor_support/environments/tst_py35.yml
+++ b/.appveyor_support/environments/tst_py35.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.5.0
   - pytest==3.8.1
+  - pytest-flake8==1.0.1
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.appveyor_support/environments/tst_py36.yml
+++ b/.appveyor_support/environments/tst_py36.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.7.2
   - pytest==3.8.2
+  - pytest-flake8==1.0.4
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.appveyor_support/environments/tst_py37.yml
+++ b/.appveyor_support/environments/tst_py37.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==19.0.1
   - wheel==0.32.3
   - coverage==4.5.2
+  - flake8==3.7.2
   - pytest==4.2.0
+  - pytest-flake8==1.0.4
   - dask==1.1.1
   - numpy==1.15.4
   - scipy==1.2.0

--- a/.circleci/environments/tst_py27.yml
+++ b/.circleci/environments/tst_py27.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.7.2
   - pytest==3.8.2
+  - pytest-flake8==1.0.4
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.circleci/environments/tst_py35.yml
+++ b/.circleci/environments/tst_py35.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.5.0
   - pytest==3.8.1
+  - pytest-flake8==1.0.1
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.circleci/environments/tst_py36.yml
+++ b/.circleci/environments/tst_py36.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.7.2
   - pytest==3.8.2
+  - pytest-flake8==1.0.4
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.circleci/environments/tst_py37.yml
+++ b/.circleci/environments/tst_py37.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==19.0.1
   - wheel==0.32.3
   - coverage==4.5.2
+  - flake8==3.7.2
   - pytest==4.2.0
+  - pytest-flake8==1.0.4
   - dask==1.1.1
   - numpy==1.16.0
   - scipy==1.2.0

--- a/.travis_support/environments/tst_py27.yml
+++ b/.travis_support/environments/tst_py27.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.7.2
   - pytest==3.8.2
+  - pytest-flake8==1.0.4
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.travis_support/environments/tst_py35.yml
+++ b/.travis_support/environments/tst_py35.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.5.0
   - pytest==3.8.1
+  - pytest-flake8==1.0.1
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.travis_support/environments/tst_py36.yml
+++ b/.travis_support/environments/tst_py36.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==18.0
   - wheel==0.31.1
   - coverage==4.5.1
+  - flake8==3.7.2
   - pytest==3.8.2
+  - pytest-flake8==1.0.4
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0

--- a/.travis_support/environments/tst_py37.yml
+++ b/.travis_support/environments/tst_py37.yml
@@ -8,7 +8,9 @@ dependencies:
   - pip==19.0.1
   - wheel==0.32.3
   - coverage==4.5.2
+  - flake8==3.7.2
   - pytest==4.2.0
+  - pytest-flake8==1.0.4
   - dask==1.1.1
   - numpy==1.16.0
   - scipy==1.2.0

--- a/dask_image/ndfilters/__init__.py
+++ b/dask_image/ndfilters/__init__.py
@@ -8,38 +8,25 @@ from ._conv import (
     convolve,
     correlate,
 )
-convolve.__module__ = __name__
-correlate.__module__ = __name__
 
 from ._diff import (
     laplace,
 )
-laplace.__module__ = __name__
-
 
 from ._edge import (
     prewitt,
     sobel,
 )
-prewitt.__module__ = __name__
-sobel.__module__ = __name__
-
 
 from ._gaussian import (
     gaussian_filter,
     gaussian_gradient_magnitude,
     gaussian_laplace,
 )
-gaussian_filter.__module__ = __name__
-gaussian_gradient_magnitude.__module__ = __name__
-gaussian_laplace.__module__ = __name__
-
 
 from ._generic import (
     generic_filter,
 )
-generic_filter.__module__ = __name__
-
 
 from ._order import (
     minimum_filter,
@@ -48,14 +35,30 @@ from ._order import (
     rank_filter,
     percentile_filter,
 )
+
+from ._smooth import (
+    uniform_filter,
+)
+
+
+convolve.__module__ = __name__
+correlate.__module__ = __name__
+
+laplace.__module__ = __name__
+
+prewitt.__module__ = __name__
+sobel.__module__ = __name__
+
+gaussian_filter.__module__ = __name__
+gaussian_gradient_magnitude.__module__ = __name__
+gaussian_laplace.__module__ = __name__
+
+generic_filter.__module__ = __name__
+
 minimum_filter.__module__ = __name__
 median_filter.__module__ = __name__
 maximum_filter.__module__ = __name__
 rank_filter.__module__ = __name__
 percentile_filter.__module__ = __name__
 
-
-from ._smooth import (
-    uniform_filter,
-)
 uniform_filter.__module__ = __name__

--- a/dask_image/ndfilters/_diff.py
+++ b/dask_image/ndfilters/_diff.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import numbers
-
 import scipy.ndimage.filters
 
 from . import _utils

--- a/dask_image/ndfilters/_generic.py
+++ b/dask_image/ndfilters/_generic.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import numbers
-
-import numpy
 import scipy.ndimage.filters
 
 from . import _utils

--- a/dask_image/ndfilters/_order.py
+++ b/dask_image/ndfilters/_order.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import numbers
-
-import numpy
 import scipy.ndimage.filters
 
 from . import _utils

--- a/dask_image/ndfilters/_smooth.py
+++ b/dask_image/ndfilters/_smooth.py
@@ -7,6 +7,9 @@ from . import _utils
 from ._gaussian import gaussian_filter
 
 
+gaussian_filter = gaussian_filter
+
+
 @_utils._update_wrapper(scipy.ndimage.filters.uniform_filter)
 def uniform_filter(input,
                    size=3,

--- a/dask_image/ndfilters/_smooth.py
+++ b/dask_image/ndfilters/_smooth.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import numbers
-
-import numpy
 import scipy.ndimage.filters
 
 from . import _utils

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -14,8 +14,8 @@ from .._pycompat import irange, izip, strlike
 
 def _get_docstring(func):
     # Drop the output parameter from the docstring.
-    split_doc_params = lambda s: \
-        re.subn("(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")  # noqa: E731
+    split_doc_params = lambda s: re.subn(
+        "(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")          # noqa: E731
     drop_doc_param = lambda s: not s.startswith("    output : ")  # noqa: E731
     func_doc = "" if func.__doc__ is None else func.__doc__
     cleaned_docstring = "".join([

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -14,7 +14,7 @@ from .._pycompat import irange, izip, strlike
 
 def _get_docstring(func):
     # Drop the output parameter from the docstring.
-    split_doc_params = lambda s: re.subn(
+    split_doc_params = lambda s: re.subn(                         # noqa: E731
         "(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")          # noqa: E731
     drop_doc_param = lambda s: not s.startswith("    output : ")  # noqa: E731
     func_doc = "" if func.__doc__ is None else func.__doc__

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -15,7 +15,7 @@ from .._pycompat import irange, izip, strlike
 def _get_docstring(func):
     # Drop the output parameter from the docstring.
     split_doc_params = lambda s: re.subn(                         # noqa: E731
-        "(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")          # noqa: E731
+        "(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")
     drop_doc_param = lambda s: not s.startswith("    output : ")  # noqa: E731
     func_doc = "" if func.__doc__ is None else func.__doc__
     cleaned_docstring = "".join([

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -15,8 +15,8 @@ from .._pycompat import irange, izip, strlike
 def _get_docstring(func):
     # Drop the output parameter from the docstring.
     split_doc_params = lambda s: \
-        re.subn("(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")
-    drop_doc_param = lambda s: not s.startswith("    output : ")
+        re.subn("(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")  # noqa: E731
+    drop_doc_param = lambda s: not s.startswith("    output : ")  # noqa: E731
     func_doc = "" if func.__doc__ is None else func.__doc__
     cleaned_docstring = "".join([
         l for l in split_doc_params(func_doc) if drop_doc_param(l)
@@ -87,7 +87,7 @@ def _get_depth_boundary(ndim, depth, boundary=None):
     if not isinstance(boundary, collections.Mapping):
         raise TypeError("Unexpected type for `boundary`.")
 
-    type_check = lambda b: (b is None) or isinstance(b, strlike)
+    type_check = lambda b: (b is None) or isinstance(b, strlike)  # noqa: E731
     if not all(map(type_check, boundary.values())):
         raise TypeError("Expected string-like values for `boundary`.")
 

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -9,7 +9,7 @@ import re
 
 import numpy
 
-from .._pycompat import imap, irange, izip, strlike, unicode
+from .._pycompat import irange, izip, strlike
 
 
 def _get_docstring(func):

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -7,7 +7,7 @@ import numpy
 
 import dask.array
 
-from .._pycompat import imap, irange, izip
+from .._pycompat import izip
 
 
 def _get_freq_grid(shape, chunks, dtype=float):

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import itertools
 import numbers
 
 import numpy

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -212,7 +212,8 @@ def label(input, structure=None):
 
     if not all([len(c) == 1 for c in input.chunks]):
         warn(
-            "``input`` does not have 1 chunk in all dimensions; it will be consolidated first",
+            "``input`` does not have 1 chunk in all dimensions; "
+            "it will be consolidated first",
             RuntimeWarning
         )
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -211,7 +211,10 @@ def label(input, structure=None):
     input = dask.array.asarray(input)
 
     if not all([len(c) == 1 for c in input.chunks]):
-        warn("``input`` does not have 1 chunk in all dimensions; it will be consolidated first", RuntimeWarning)
+        warn(
+            "``input`` does not have 1 chunk in all dimensions; it will be consolidated first",
+            RuntimeWarning
+        )
 
     label_func = dask.delayed(scipy.ndimage.label, nout=2)
     label, num_features = label_func(input, structure)

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -10,8 +10,6 @@ import numpy
 import dask
 import dask.array
 
-from .. import _pycompat
-
 
 def _norm_input_labels_index(input, labels=None, index=None):
     """

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -3,7 +3,6 @@
 
 from __future__ import division
 
-import operator
 import warnings
 
 import numpy

--- a/dask_image/ndmorph/_ops.py
+++ b/dask_image/ndmorph/_ops.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import numpy
-
 import dask.array
 
 from . import _utils

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -15,6 +15,11 @@ from ..ndfilters._utils import (
     _get_depth
 )
 
+_update_wrapper = _update_wrapper
+_get_depth_boundary = _get_depth_boundary
+_get_origin = _get_origin
+_get_depth = _get_depth
+
 
 def _get_structure(input, structure):
     # Create square connectivity as default

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -9,13 +9,10 @@ import scipy.ndimage
 import dask.array
 
 from ..ndfilters._utils import (
-    _get_docstring,
     _update_wrapper,
     _get_depth_boundary,
-    _get_size,
     _get_origin,
-    _get_depth,
-    _get_footprint
+    _get_depth
 )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ parentdir_prefix = dask-image
 universal = 1
 
 [flake8]
-exclude = docs
+exclude = docs/conf.py,versioneer.py
 
 [pytest]
 addopts = --flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@ universal = 1
 
 [flake8]
 exclude = docs
+
+[pytest]
+addopts = --flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,5 @@ universal = 1
 [flake8]
 exclude = docs/conf.py,versioneer.py
 
-[pytest]
+[tool:pytest]
 addopts = --flake8

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ requirements = [
 ]
 
 test_requirements = [
+    "flake8 >=3.4.1",
     "pytest >=3.0.5",
+    "pytest-flake8 >=0.8.1",
     "scikit-image >=0.12.3",
 ]
 

--- a/tests/test_dask_image/test__pycompat.py
+++ b/tests/test_dask_image/test__pycompat.py
@@ -16,7 +16,7 @@ def test_irange():
 
 
 def test_imap():
-    r = dask_image._pycompat.imap(lambda e : e ** 2, [0, 1, 2, 3])
+    r = dask_image._pycompat.imap(lambda e: e ** 2, [0, 1, 2, 3])
 
     assert not isinstance(r, list)
 

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -188,7 +188,8 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
         (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
     ]
 )
-def test_gaussian_derivative_filters_compare(sp_func, da_func, order, sigma, truncate):
+def test_gaussian_derivative_filters_compare(sp_func, da_func,
+                                             order, sigma, truncate):
     s = (100, 110)
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(50, 55))

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -140,9 +140,12 @@ def test_gaussian_filter_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
-        (sp_ndf.gaussian_gradient_magnitude, da_ndf.gaussian_gradient_magnitude),
-        (sp_ndf.gaussian_laplace, da_ndf.gaussian_laplace),
+        (sp_ndf.gaussian_filter,
+         da_ndf.gaussian_filter),
+        (sp_ndf.gaussian_gradient_magnitude,
+         da_ndf.gaussian_gradient_magnitude),
+        (sp_ndf.gaussian_laplace,
+         da_ndf.gaussian_laplace),
     ]
 )
 def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -113,7 +113,7 @@ def test_gaussian_filter_shape_type(da_func):
     ]
 )
 def test_gaussian_filter_comprehensions(da_func):
-    da_wfunc = lambda arr: da_func(arr, 1.0, truncate=4.0)
+    da_wfunc = lambda arr: da_func(arr, 1.0, truncate=4.0)  # noqa: E731
 
     np.random.seed(0)
 

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -67,7 +67,7 @@ def test_generic_filters_params(da_func,
     ]
 )
 def test_generic_filter_shape_type(da_func):
-    function = lambda x: x
+    function = lambda x: x  # noqa: E731
     size = 1
 
     a = np.arange(140.0).reshape(10, 14)
@@ -119,7 +119,7 @@ def test_generic_filter_identity(sp_func,
     ]
 )
 def test_generic_filter_comprehensions(da_func):
-    da_wfunc = lambda arr: da_func(arr, lambda x: x, 1)
+    da_wfunc = lambda arr: da_func(arr, lambda x: x, 1)  # noqa: E731
 
     np.random.seed(0)
 

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -155,11 +155,16 @@ def test_order_comprehensions(da_func, kwargs):
 @pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
-        (sp_ndf.minimum_filter, da_ndf.minimum_filter, {}),
-        (sp_ndf.median_filter, da_ndf.median_filter, {}),
-        (sp_ndf.maximum_filter, da_ndf.maximum_filter, {}),
-        (sp_ndf.rank_filter, da_ndf.rank_filter, {"rank": 1}),
-        (sp_ndf.percentile_filter, da_ndf.percentile_filter, {"percentile": 10}),
+        (sp_ndf.minimum_filter,
+         da_ndf.minimum_filter, {}),
+        (sp_ndf.median_filter,
+         da_ndf.median_filter, {}),
+        (sp_ndf.maximum_filter,
+         da_ndf.maximum_filter, {}),
+        (sp_ndf.rank_filter,
+         da_ndf.rank_filter, {"rank": 1}),
+        (sp_ndf.percentile_filter,
+         da_ndf.percentile_filter, {"percentile": 10}),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -91,11 +91,16 @@ def test_ordered_filter_shape_type(da_func,
 @pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
-        (sp_ndf.minimum_filter, da_ndf.minimum_filter, {}),
-        (sp_ndf.median_filter, da_ndf.median_filter, {}),
-        (sp_ndf.maximum_filter, da_ndf.maximum_filter, {}),
-        (sp_ndf.rank_filter, da_ndf.rank_filter, {"rank": 0}),
-        (sp_ndf.percentile_filter, da_ndf.percentile_filter, {"percentile": 0}),
+        (sp_ndf.minimum_filter,
+         da_ndf.minimum_filter, {}),
+        (sp_ndf.median_filter,
+         da_ndf.median_filter, {}),
+        (sp_ndf.maximum_filter,
+         da_ndf.maximum_filter, {}),
+        (sp_ndf.rank_filter,
+         da_ndf.rank_filter, {"rank": 0}),
+        (sp_ndf.percentile_filter,
+         da_ndf.percentile_filter, {"percentile": 0}),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -52,7 +52,7 @@ def test_uniform_shape_type():
 
 
 def test_uniform_comprehensions():
-    da_func = lambda arr: da_ndf.uniform_filter(arr, 1, origin=0)
+    da_func = lambda arr: da_ndf.uniform_filter(arr, 1, origin=0)  # noqa: E731
 
     np.random.seed(0)
 

--- a/tests/test_dask_image/test_ndfilters/test__utils.py
+++ b/tests/test_dask_image/test_ndfilters/test__utils.py
@@ -43,7 +43,6 @@ def test__update_wrapper():
     def g():
         return f()
 
-
     assert f.__name__ == g.__name__
 
     expected = """

--- a/tests/test_dask_image/test_ndfilters/test__utils.py
+++ b/tests/test_dask_image/test_ndfilters/test__utils.py
@@ -13,7 +13,7 @@ from dask_image.ndfilters import _utils
 
 
 def test__get_docstring():
-    f = lambda: 0
+    f = lambda: 0  # noqa: E731
 
     result = _utils._get_docstring(f)
 
@@ -37,7 +37,7 @@ def test__get_docstring():
 
 
 def test__update_wrapper():
-    f = lambda: 0
+    f = lambda: 0  # noqa: E731
 
     @_utils._update_wrapper(f)
     def g():

--- a/tests/test_dask_image/test_ndfilters/test__utils.py
+++ b/tests/test_dask_image/test_ndfilters/test__utils.py
@@ -13,7 +13,7 @@ from dask_image.ndfilters import _utils
 
 
 def test__get_docstring():
-    f = lambda : 0
+    f = lambda: 0
 
     result = _utils._get_docstring(f)
 
@@ -37,7 +37,7 @@ def test__get_docstring():
 
 
 def test__update_wrapper():
-    f = lambda : 0
+    f = lambda: 0
 
     @_utils._update_wrapper(f)
     def g():
@@ -68,10 +68,10 @@ def test__update_wrapper():
 @pytest.mark.parametrize(
     "err_type, ndim, depth, boundary",
     [
-        (TypeError, lambda : 0, 1, None),
+        (TypeError, lambda: 0, 1, None),
         (TypeError, 1.0, 1, None),
         (ValueError, -1, 1, None),
-        (TypeError, 1, lambda : 0, None),
+        (TypeError, 1, lambda: 0, None),
         (TypeError, 1, 1.0, None),
         (ValueError, 1, -1, None),
         (ValueError, 1, (1, 1), None),

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -100,8 +100,8 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
             dtype is np.int64 or
             dtype is np.float64
         ) and (
-            funcname is "fourier_gaussian" or
-            funcname is "fourier_uniform"
+            funcname == "fourier_gaussian" or
+            funcname == "fourier_uniform"
         )):
         pytest.skip(
             "SciPy 1.0.0+ doesn't handle double precision values correctly."

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -96,13 +96,11 @@ def test_fourier_filter_identity(funcname, s):
     ]
 )
 def test_fourier_filter_type(funcname, upcast_type, dtype):
-    if (LooseVersion(sp.__version__) >= "1.0.0" and (
-            dtype is np.int64 or
-            dtype is np.float64
-        ) and (
-            funcname == "fourier_gaussian" or
-            funcname == "fourier_uniform"
-        )):
+    if (
+            LooseVersion(sp.__version__) >= "1.0.0" and
+            dtype in [np.int64, np.float64] and
+            funcname in ["fourier_gaussian", "fourier_uniform"]
+       ):
         pytest.skip(
             "SciPy 1.0.0+ doesn't handle double precision values correctly."
         )

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -42,7 +42,7 @@ def test__norm_input_labels_index():
     lbls = (a < 0.5).astype(int)
     d_lbls = da.from_array(lbls, chunks=d.chunks)
 
-    d_n, d_lbls_n, ind_n = dask_image.ndmeasure._utils._norm_input_labels_index(
+    d_n, d_lbls_n, ind_n = dask_image.ndmeasure._utils._norm_input_labels_index(  # noqa: E501
         d, d_lbls, ind
     )
 

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -3,8 +3,6 @@
 
 from __future__ import absolute_import
 
-import operator
-
 import pytest
 
 import numpy as np

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -123,9 +123,11 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
 
     # See the linked issue for details.
     # ref: https://github.com/scipy/scipy/issues/7706
-    if (funcname == "median" and
-        ind is not None and
-        not np.in1d(np.atleast_1d(ind), lbls).all()):
+    if (
+            funcname == "median" and
+            ind is not None and
+            not np.in1d(np.atleast_1d(ind), lbls).all()
+       ):
         pytest.skip("SciPy's `median` mishandles missing labels.")
 
     assert np.allclose(np.array(a_r), np.array(d_r), equal_nan=True)

--- a/tests/test_dask_image/test_ndmorph/test__utils.py
+++ b/tests/test_dask_image/test_ndmorph/test__utils.py
@@ -97,7 +97,7 @@ def test_errs__get_brute_force(err_type, brute_force):
         ),
         (
             numpy.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool),
-            (dask.array.arange(100, chunks=10).reshape(10, 10) % 2).astype(bool),
+            (dask.array.arange(100, chunks=10).reshape(10, 10) % 2).astype(bool),  # noqa: E501
             None
         ),
         (


### PR DESCRIPTION
Updates the test suite to use flake8 to lint the code as part of the pytest run. Also fixes several errors caught by running flake8.