### PR TITLE
Added a port of scipy.ndimage.measurement.watershed.

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -649,3 +649,97 @@ def variance(input, labels=None, index=None):
     )
 
     return var_lbl
+
+# this version of a watershed alg. is adapted from scipy.ndimage.measurement
+def watershed_ift(input, markers, structure=None, output=None):
+    """
+    Apply watershed from markers using image foresting transform algorithm.
+
+    Parameters
+    ----------
+    input : array_like
+        Input.
+    markers : array_like
+        Markers are points within each watershed that form the beginning
+        of the process.  Negative markers are considered background markers
+        which are processed after the other markers.
+    structure : structure element, optional
+        A structuring element defining the connectivity of the object can be
+        provided. If None, an element is generated with a squared
+        connectivity equal to one.
+    output : ndarray, optional
+        An output array can optionally be provided.  The same shape as input.
+
+    Returns
+    -------
+    watershed_ift : ndarray
+        Output.  Same shape as `input`.
+
+    References
+    ----------
+    .. [1] A.X. Falcao, J. Stolfi and R. de Alencar Lotufo, "The image
+           foresting transform: theory, algorithms, and applications",
+           Pattern Analysis and Machine Intelligence, vol. 26, pp. 19-29, 2004.
+
+    """
+    print("Warning: watershed is a stub")
+    warn("Warning: watershed is a stub", RuntimeWarning)
+
+    input = dask.array.asarray(input)
+
+    if input.dtype.type not in [numpy.uint8, numpy.uint16]:
+        raise TypeError('only 8 and 16 unsigned inputs are supported')
+
+    if not all([len(c) == 1 for c in input.chunks]):
+        warn("``input`` does not have 1 chunk in all dimensions; it will be consolidated first", RuntimeWarning)
+
+    if structure is None:
+        structure = scipy.ndimage.generate_binary_structure(input.ndim, 1)
+    structure = dask.array.asarray(structure, dtype=bool)
+    if structure.ndim != input.ndim:
+        raise RuntimeError('structure and input must have equal rank')
+    for ii in structure.shape:
+        if ii != 3:
+            raise RuntimeError('structure dimensions must be equal to 3')
+
+    return None # 
+    #input = numpy.asarray(input)
+    #if input.dtype.type not in [numpy.uint8, numpy.uint16]:
+    #    raise TypeError('only 8 and 16 unsigned inputs are supported')
+
+    if structure is None:
+        structure = scipy.ndimage.generate_binary_structure(input.ndim, 1)
+    structure = numpy.asarray(structure, dtype=bool)
+    if structure.ndim != input.ndim:
+        raise RuntimeError('structure and input must have equal rank')
+    for ii in structure.shape:
+        if ii != 3:
+            raise RuntimeError('structure dimensions must be equal to 3')
+
+    if not structure.flags.contiguous:
+        structure = structure.copy()
+    markers = numpy.asarray(markers)
+    if input.shape != markers.shape:
+        raise RuntimeError('input and markers must have equal shape')
+
+    integral_types = [numpy.int0,
+                      numpy.int8,
+                      numpy.int16,
+                      numpy.int32,
+                      numpy.int_,
+                      numpy.int64,
+                      numpy.intc,
+                      numpy.intp]
+
+    if markers.dtype.type not in integral_types:
+        raise RuntimeError('marker should be of integer type')
+
+    if isinstance(output, numpy.ndarray):
+        if output.dtype.type not in integral_types:
+            raise RuntimeError('output should be of integer type')
+    else:
+        output = markers.dtype
+
+    output = _ni_support._get_output(output, input)
+    _nd_image.watershed_ift(input, markers, structure, output)
+    return output

--- a/dask_image/ndmeasure/_utils.py
+++ b/dask_image/ndmeasure/_utils.py
@@ -33,7 +33,7 @@ def _norm_input_labels_index(input, labels=None, index=None):
 
     if index.ndim > 1:
         warnings.warn(
-            "Having index with dimensionality greater than 1 is undefined.",
+            "Having index with dimensionality (%d) greater than 1 is undefined."%index.ndim,
             FutureWarning
         )
 


### PR DESCRIPTION
I feel it might be a little to soon for a PR, but...

I got the watershed algorithm ported from scipy.ndimage.measurement.watershed working the same way that dask-image.label works. 

I will have time to work on this this weekend a little if we can discuss what needs to be done to clean things up.

Sorr, I thought I had posted some comments on a week ago and realized this morning that I posted the numba version of the code to the numba list.  

It would be nice to do a little profiling to see if I can get numba working with the low level dask stuff, but I have not heard back from the dask/dask-image folks if that is acceptable.

Let me know how you wish for me to proceed.
==========================
dask.array.atop was depricated and moved to dask.array.blockwise.

Before you submit a pull request, check that it meets these guidelines:

1. The pull request should include tests.
2. If the pull request adds functionality, the docs should be updated. Put
   your new functionality into a function with a docstring, and add the
   feature to the list in README.rst.
3. The pull request should work for Python 2.7, 3.5, 3.6, and 3.7. Check
   https://travis-ci.org/dask/dask-image/pull_requests
   and make sure that the tests pass for all supported Python versions.
