### PR TITLE
Optimize out first `where` in `label`

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -215,8 +215,9 @@ def label(input, structure=None):
     # First, label each block independently, incrementing the labels in that
     # block by the total number of labels from previous blocks. This way, each
     # block's labels are globally unique.
-    for index, cslice in zip(numpy.ndindex(*input.numblocks),
-                             dask.array.core.slices_from_chunks(input.chunks)):
+    block_iter = zip(numpy.ndindex(*input.numblocks),
+                     dask.array.core.slices_from_chunks(input.chunks))
+    for index, cslice in block_iter:
         input_block = input[cslice]
         labeled_block, n = _label.block_ndi_label_delayed(input_block,
                                                           structure)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -6,6 +6,7 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 
 import collections
 import functools
+import operator
 
 import numpy
 
@@ -216,7 +217,7 @@ def label(input, structure=None):
     # block's labels are globally unique.
     block_iter = _pycompat.izip(
         numpy.ndindex(*input.numblocks),
-        _pycompat.imap(lambda sl: input[sl],
+        _pycompat.imap(functools.partial(operator.getitem, input),
                        dask.array.core.slices_from_chunks(input.chunks))
     )
     index, input_block = next(block_iter)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -214,10 +214,10 @@ def label(input, structure=None):
     # First, label each block independently, incrementing the labels in that
     # block by the total number of labels from previous blocks. This way, each
     # block's labels are globally unique.
-    block_iter = zip(
+    block_iter = _pycompat.izip(
         numpy.ndindex(*input.numblocks),
-        map(lambda sl: input[sl],
-            dask.array.core.slices_from_chunks(input.chunks))
+        _pycompat.imap(lambda sl: input[sl],
+                       dask.array.core.slices_from_chunks(input.chunks))
     )
     index, input_block = next(block_iter)
     labeled_blocks[index], total = _label.block_ndi_label_delayed(input_block,

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -211,7 +211,6 @@ def label(input, structure=None):
     input = dask.array.asarray(input)
 
     labeled_blocks = numpy.empty(input.numblocks, dtype=object)
-    total = _label.LABEL_DTYPE.type(0)
 
     # First, label each block independently, incrementing the labels in that
     # block by the total number of labels from previous blocks. This way, each
@@ -221,6 +220,9 @@ def label(input, structure=None):
         zip(numpy.ndindex(*input.numblocks),
             dask.array.core.slices_from_chunks(input.chunks))
     )
+    index, input_block = next(block_iter)
+    labeled_blocks[index], total = _label.block_ndi_label_delayed(input_block,
+                                                                  structure)
     for index, input_block in block_iter:
         labeled_block, n = _label.block_ndi_label_delayed(input_block,
                                                           structure)

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -6,7 +6,6 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 
 import collections
 import functools
-import itertools
 
 import numpy
 
@@ -215,9 +214,9 @@ def label(input, structure=None):
     # First, label each block independently, incrementing the labels in that
     # block by the total number of labels from previous blocks. This way, each
     # block's labels are globally unique.
-    block_iter = itertools.starmap(
-        lambda i, sl: (i, input[sl]),
-        zip(numpy.ndindex(*input.numblocks),
+    block_iter = zip(
+        numpy.ndindex(*input.numblocks),
+        map(lambda sl: input[sl],
             dask.array.core.slices_from_chunks(input.chunks))
     )
     index, input_block = next(block_iter)


### PR DESCRIPTION
This optimize out the first call to `where` in `label` as that case should be a no-op as it merely adds `0` to the first block's label image.

---

Before you submit a pull request, check that it meets these guidelines:

1. The pull request should include tests.
2. If the pull request adds functionality, the docs should be updated. Put
   your new functionality into a function with a docstring, and add the
   feature to the list in README.rst.
3. The pull request should work for Python 2.7, 3.5, 3.6, and 3.7. Check
   https://travis-ci.org/dask/dask-image/pull_requests
   and make sure that the tests pass for all supported Python versions.
