### PR TITLE
Add dask-image quickstart documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents
    :maxdepth: 1
 
    installation
+   quickstart
    api
    contributing
    authors

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -62,14 +62,6 @@ See the dask_array_documentation_ for more detail on general array operations.
 
     result = function_name(images)
 
-Remember that dask computations are lazy. 
-That's a great thing to have, most of the time.
-If you need to force dask to run the computation, use the `compute()` method.
-
-.. code-block:: python
-
-    result.compute()
-
 
 Further Reading
 ---------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,9 +22,9 @@ We highly recommend checking out the dask-image-quickstart.ipynb notebook
 
 https://github.com/dask/dask-examples
 
-All the example notebooks are available to launch with mybinder and test out
-interactively.
-
+You can find the dask-image quickstart notebook in the `applications` folder
+of this repository. All the example notebooks are available to launch with
+mybinder and test out interactively.
 
 
 An Even Quicker Start

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,77 @@
+.. highlight:: shell
+
+==========
+Quickstart
+==========
+
+
+Importing dask-image
+--------------------
+Import dask image is with an underscore, like this example:
+
+.. code-block:: python
+
+    import dask_image.imread
+    import dask_image.ndfilters
+
+
+Dask Examples
+-------------
+We highly recommend checking out the dask-image-quickstart.ipynb notebook 
+(and any other dask-image example notebooks) at the dask-examples repository:
+
+https://github.com/dask/dask-examples
+
+All the example notebooks are available to launch with mybinder and test out
+interactively.
+
+
+
+An Even Quicker Start
+---------------------
+
+You can read files stored on disk into a dask array
+by passing the filename, or regex matching multiple filenames
+into `imread()`.
+
+.. code-block:: python
+
+    filename_pattern = 'path/to/image-*.png'
+    images = dask_image.imread.imread(filename_pattern)
+
+If your images are parts of a much larger image, 
+dask can stack, concatenate or block chunks together:
+http://docs.dask.org/en/latest/array-stack.html
+
+
+Calling dask-image functions is also easy.
+.. code-block:: python
+
+    import dask_image.ndfilters
+    blurred_image = dask_image.ndfilters.gaussian_filter(images, sigma=10)
+
+
+If you have a function that accepts input numpy arrays,
+it is also likely to accept dask arrays without any modification. 
+
+.. code-block:: python
+
+    result = my_function(images)
+
+Remember that dask computations are lazy. 
+That's a great thing to have, most of the time.
+If you need to force dask to run the computation, use the `compute()` method.
+
+.. code-block:: python
+
+    result.compute()
+
+
+Further Reading
+---------------
+
+Good places to start include:
+
+* The dask-image API documentation: http://image.dask.org/en/latest/api.html
+* The documentation on working with dask arrays: http://docs.dask.org/en/latest/array.html
+

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,7 @@ Dask Examples
 -------------
 We highly recommend checking out the dask-image-quickstart.ipynb notebook 
 (and any other dask-image example notebooks) at the dask-examples repository.
-You can find the dask-image quickstart notebook in the `applications` folder
+You can find the dask-image quickstart notebook in the ``applications`` folder
 of this repository:
 
 https://github.com/dask/dask-examples
@@ -33,7 +33,7 @@ An Even Quicker Start
 
 You can read files stored on disk into a dask array
 by passing the filename, or regex matching multiple filenames
-into `imread()`.
+into ``imread()``.
 
 .. code-block:: python
 
@@ -54,8 +54,9 @@ Calling dask-image functions is also easy.
 
 
 Many other functions can be applied to dask arrays.
-See the [dask array documentation](http://docs.dask.org/en/latest/array.html)
-for more detail on general array operations.
+See the dask_array_documentation_ for more detail on general array operations.
+
+.. _dask_array_documentation: http://docs.dask.org/en/latest/array.html
 
 .. code-block:: python
 
@@ -77,4 +78,3 @@ Good places to start include:
 
 * The dask-image API documentation: http://image.dask.org/en/latest/api.html
 * The documentation on working with dask arrays: http://docs.dask.org/en/latest/array.html
-

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,12 +18,13 @@ Import dask image is with an underscore, like this example:
 Dask Examples
 -------------
 We highly recommend checking out the dask-image-quickstart.ipynb notebook 
-(and any other dask-image example notebooks) at the dask-examples repository:
+(and any other dask-image example notebooks) at the dask-examples repository.
+You can find the dask-image quickstart notebook in the `applications` folder
+of this repository:
 
 https://github.com/dask/dask-examples
 
-You can find the dask-image quickstart notebook in the `applications` folder
-of this repository. All the example notebooks are available to launch with
+All the example notebooks are available to launch with
 mybinder and test out interactively.
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,18 +46,20 @@ http://docs.dask.org/en/latest/array-stack.html
 
 
 Calling dask-image functions is also easy.
+
 .. code-block:: python
 
     import dask_image.ndfilters
     blurred_image = dask_image.ndfilters.gaussian_filter(images, sigma=10)
 
 
-If you have a function that accepts input numpy arrays,
-it is also likely to accept dask arrays without any modification. 
+Many other functions can be applied to dask arrays.
+See the [dask array documentation](http://docs.dask.org/en/latest/array.html)
+for more detail on general array operations.
 
 .. code-block:: python
 
-    result = my_function(images)
+    result = function_name(images)
 
 Remember that dask computations are lazy. 
 That's a great thing to have, most of the time.


### PR DESCRIPTION
# Documentation update
Added:
* Brief text for quickstart.rst in the dask-image docs
* Links to the dask-examples repository (specifically of interest is dask-image-quickstart,ipynb)

Is this the right way to update the docs? I checked the restructured text formatting with http://rst.ninjs.org but should I be trying to run sphinx to check left hand sidebar updates to have a 'quickstart' tab too?