### PR TITLE
Rename labels in ndmeasure function arguments

### DIFF
--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -20,6 +20,7 @@ def _get_docstring(func):
         l for l in split_doc_params(func_doc) if drop_doc_param(l)
     ])
     cleaned_docstring = cleaned_docstring.replace('input', 'image')
+    cleaned_docstring = cleaned_docstring.replace('labels', 'label_image')
     cleaned_docstring = cleaned_docstring.split('Examples')[0].strip()
 
     docstring = """

--- a/dask_image/ndmeasure/_utils/__init__.py
+++ b/dask_image/ndmeasure/_utils/__init__.py
@@ -17,21 +17,23 @@ except ImportError:
     from dask.array import atop as da_blockwise
 
 
-def _norm_input_labels_index(image, labels=None, index=None):
+def _norm_input_labels_index(image, label_image=None, index=None):
     """
     Normalize arguments to a standard form.
     """
 
     image = dask.array.asarray(image)
 
-    if labels is None:
-        labels = dask.array.ones(image.shape, dtype=int, chunks=image.chunks)
+    if label_image is None:
+        label_image = dask.array.ones(
+            image.shape, dtype=int, chunks=image.chunks,
+        )
         index = dask.array.ones(tuple(), dtype=int, chunks=tuple())
     elif index is None:
-        labels = (labels > 0).astype(int)
+        label_image = (label_image > 0).astype(int)
         index = dask.array.ones(tuple(), dtype=int, chunks=tuple())
 
-    labels = dask.array.asarray(labels)
+    label_image = dask.array.asarray(label_image)
     index = dask.array.asarray(index)
 
     if index.ndim > 1:
@@ -40,10 +42,12 @@ def _norm_input_labels_index(image, labels=None, index=None):
             FutureWarning
         )
 
-    if image.shape != labels.shape:
-        raise ValueError("The image and labels arrays must be the same shape.")
+    if image.shape != label_image.shape:
+        raise ValueError(
+            "The image and label_image arrays must be the same shape."
+        )
 
-    return (image, labels, index)
+    return (image, label_image, index)
 
 
 def _ravel_shape_indices_kernel(*args):

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -32,7 +32,7 @@ import dask_image.ndmeasure
         "variance",
     ]
 )
-def _props_err(funcname):
+def test_measure_props_err(funcname):
     da_func = getattr(dask_image.ndmeasure, funcname)
 
     shape = (15, 16)

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -32,7 +32,7 @@ import dask_image.ndmeasure
         "variance",
     ]
 )
-def test_measure_props_err(funcname):
+def _props_err(funcname):
     da_func = getattr(dask_image.ndmeasure, funcname)
 
     shape = (15, 16)


### PR DESCRIPTION
Rename `labels` argument to `label_image` to be more descriptive.

Modify `get_docstring` to modify docstrings based on the change above.