### PR TITLE
Use tifffile for testing instead of scikit-image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ test_requirements = [
     "flake8 >=3.4.1",
     "pytest >=3.0.5",
     "pytest-flake8 >=0.8.1",
-    "scikit-image >=0.12.3",
+    "tifffile >=2018.10.18",
 ]
 
 cmdclasses = {

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -9,7 +9,7 @@ import numbers
 import pytest
 
 import numpy as np
-from skimage.external import tifffile
+import tifffile
 
 import dask.array.utils as dau
 import dask_image.imread


### PR DESCRIPTION
As scikit-image has dropped their vendored copy of tifffile ( https://github.com/scikit-image/scikit-image/pull/4235 ), switch to using tifffile directly for testing our ability to read TIFFs.