### PR TITLE
Update release dependencies

### DIFF
--- a/.appveyor_support/environments/tst_py36.yml
+++ b/.appveyor_support/environments/tst_py36.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image==0.14.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.appveyor_support/environments/tst_py37.yml
+++ b/.appveyor_support/environments/tst_py37.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask==1.1.1
   - numpy==1.15.4
   - scipy==1.2.0
-  - scikit-image==0.14.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.appveyor_support/environments/tst_py38.yml
+++ b/.appveyor_support/environments/tst_py38.yml
@@ -14,6 +14,6 @@ dependencies:
   - dask==2.8.1
   - numpy==1.17.3
   - scipy==1.3.2
-  - scikit-image==0.16.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==1.0.0

--- a/.circleci/environments/tst_py36.yml
+++ b/.circleci/environments/tst_py36.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask==0.16.1
   - numpy==1.11.3
   - scipy==1.1.0
-  - scikit-image==0.14.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.circleci/environments/tst_py37.yml
+++ b/.circleci/environments/tst_py37.yml
@@ -14,7 +14,7 @@ dependencies:
   - dask==1.1.1
   - numpy==1.16.0
   - scipy==1.2.0
-  - scikit-image==0.14.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/.circleci/environments/tst_py38.yml
+++ b/.circleci/environments/tst_py38.yml
@@ -14,6 +14,6 @@ dependencies:
   - dask==2.8.1
   - numpy==1.17.3
   - scipy==1.3.2
-  - scikit-image==0.16.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==1.0.0

--- a/.travis_support/environments/tst_py36.yml
+++ b/.travis_support/environments/tst_py36.yml
@@ -18,4 +18,4 @@ dependencies:
     - pytest==3.8.2
     - pytest-flake8==1.0.4
     - dask==0.16.1
-    - scikit-image==0.14.2
+    - tifffile==2018.10.18

--- a/.travis_support/environments/tst_py37.yml
+++ b/.travis_support/environments/tst_py37.yml
@@ -18,4 +18,4 @@ dependencies:
     - pytest==5.2.0
     - pytest-flake8==1.0.4
     - dask==1.1.1
-    - scikit-image==0.14.2
+    - tifffile==2018.10.18

--- a/.travis_support/environments/tst_py38.yml
+++ b/.travis_support/environments/tst_py38.yml
@@ -14,6 +14,6 @@ dependencies:
   - dask==2.8.1
   - numpy==1.17.3
   - scipy==1.3.2
-  - scikit-image==0.16.2
+  - tifffile==2018.10.18
   - pims==0.4.1
   - slicerator==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,16 @@ requirements = [
     "numpy >=1.11.3",
     "scipy >=0.19.1",
     "pims >=0.4.1",
+    "tifffile >=2020.6.3",
+    "imageio >=2.8.0",
+    "imageio-ffmpeg >=0.4.2",
+    "jpype1 >=0.7.5",
 ]
 
 test_requirements = [
     "flake8 >=3.4.1",
     "pytest >=3.0.5",
     "pytest-flake8 >=0.8.1",
-    "scikit-image >=0.12.3",
 ]
 
 cmdclasses = {

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -9,7 +9,7 @@ import numbers
 import pytest
 
 import numpy as np
-from skimage.external import tifffile
+import tifffile
 
 import dask.array.utils as dau
 import dask_image.imread


### PR DESCRIPTION
As discussed [here](https://github.com/dask/dask-image/issues/129#issuecomment-640380667), I think it's a good idea for us to include a minimal set of dependencies to allow users to open most image files with our `imread` function. I want things "just work" out of the box.

The extra dependencies proposed here are:
* `tifffile` (for tiff files)
* `imageio` (for most other files)
* `imageio-ffmpeg` (is also required by the pims imageio reader)
* `jpype` (for bioformats files)
