### PR TITLE
GPU support proposal

### DIFF
--- a/.appveyor_support/environments/tst_py36.yml
+++ b/.appveyor_support/environments/tst_py36.yml
@@ -11,7 +11,7 @@ dependencies:
   - flake8==3.7.2
   - pytest==5.2.0
   - pytest-flake8==1.0.4
-  - dask==1.1.1
+  - dask==2.8.1
   - numpy==1.15.4
   - scipy==1.2.0
   - scikit-image==0.14.2

--- a/.appveyor_support/environments/tst_py36.yml
+++ b/.appveyor_support/environments/tst_py36.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.6.*
-  - pip==18.0
-  - wheel==0.31.1
-  - coverage==4.5.1
+  - pip==19.0.1
+  - wheel==0.32.3
+  - coverage==4.5.2
   - flake8==3.7.2
-  - pytest==3.8.2
+  - pytest==5.2.0
   - pytest-flake8==1.0.4
-  - dask==0.16.1
-  - numpy==1.11.3
-  - scipy==1.1.0
+  - dask==1.1.1
+  - numpy==1.15.4
+  - scipy==1.2.0
   - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8

--- a/.appveyor_support/environments/tst_py37.yml
+++ b/.appveyor_support/environments/tst_py37.yml
@@ -11,7 +11,7 @@ dependencies:
   - flake8==3.7.2
   - pytest==5.2.0
   - pytest-flake8==1.0.4
-  - dask==1.1.1
+  - dask==2.8.1
   - numpy==1.15.4
   - scipy==1.2.0
   - scikit-image==0.14.2

--- a/.circleci/environments/tst_py36.yml
+++ b/.circleci/environments/tst_py36.yml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - python=3.6.*
-  - pip==18.0
-  - wheel==0.31.1
-  - coverage==4.5.1
+  - pip==19.0.1
+  - wheel==0.32.3
+  - coverage==4.5.2
   - flake8==3.7.2
-  - pytest==3.8.2
+  - pytest==5.2.0
   - pytest-flake8==1.0.4
-  - dask==0.16.1
-  - numpy==1.11.3
-  - scipy==1.1.0
+  - dask==1.1.1
+  - numpy==1.16.0
+  - scipy==1.2.0
   - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator==0.9.8

--- a/.circleci/environments/tst_py36.yml
+++ b/.circleci/environments/tst_py36.yml
@@ -11,7 +11,7 @@ dependencies:
   - flake8==3.7.2
   - pytest==5.2.0
   - pytest-flake8==1.0.4
-  - dask==1.1.1
+  - dask==2.8.1
   - numpy==1.16.0
   - scipy==1.2.0
   - scikit-image==0.14.2

--- a/.circleci/environments/tst_py37.yml
+++ b/.circleci/environments/tst_py37.yml
@@ -11,7 +11,7 @@ dependencies:
   - flake8==3.7.2
   - pytest==5.2.0
   - pytest-flake8==1.0.4
-  - dask==1.1.1
+  - dask==2.8.1
   - numpy==1.16.0
   - scipy==1.2.0
   - scikit-image==0.14.2

--- a/.travis_support/environments/tst_py36.yml
+++ b/.travis_support/environments/tst_py36.yml
@@ -17,6 +17,6 @@ dependencies:
     - slicerator==0.9.8
     - pytest==5.2.0
     - pytest-flake8==1.0.4
-    - dask==1.1.1
+    - dask==2.8.1
     - scikit-image==0.14.2
 

--- a/.travis_support/environments/tst_py36.yml
+++ b/.travis_support/environments/tst_py36.yml
@@ -5,17 +5,18 @@ channels:
 
 dependencies:
   - python=3.6.*
-  - pip==18.0
-  - wheel==0.31.1
-  - coverage==4.5.1
+  - pip==19.0.1
+  - wheel==0.32.3
+  - coverage==4.5.2
   - flake8==3.7.2
-  - numpy==1.11.3
-  - scipy==1.1.0
+  - numpy==1.16.0
+  - scipy==1.2.0
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:
     - slicerator==0.9.8
-    - pytest==3.8.2
+    - pytest==5.2.0
     - pytest-flake8==1.0.4
-    - dask==0.16.1
+    - dask==1.1.1
     - scikit-image==0.14.2
+

--- a/.travis_support/environments/tst_py37.yml
+++ b/.travis_support/environments/tst_py37.yml
@@ -17,5 +17,5 @@ dependencies:
     - slicerator==0.9.8
     - pytest==5.2.0
     - pytest-flake8==1.0.4
-    - dask==1.1.1
+    - dask==2.8.1
     - scikit-image==0.14.2

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -18,7 +18,7 @@ def convolve(image,
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
 
     result = image.map_overlap(
-        dispatch_convolve,
+        dispatch_convolve(image),
         depth=depth,
         boundary=boundary,
         dtype=image.dtype,

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.ndimage.filters
 
 from . import _utils
-from ..utils import Dispatcher
+from ..utils._dispatcher import Dispatcher
 
 convolve = Dispatcher(name="convolve")
 
@@ -46,7 +46,9 @@ def register_cupy():
 
     @convolve.register(cupy.ndarray)
     def cupy_convolve(*args, **kwargs):
-        return convolve_func(cupyx.scipy.ndimage.filters.convolve, *args, **kwargs)
+        return convolve_func(cupyx.scipy.ndimage.filters.convolve,
+                             *args,
+                             **kwargs)
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.correlate)

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-
 import scipy.ndimage.filters
 
 from . import _utils
-from ..utils._dispatcher import convolve_dispatch
+from ..utils._dispatcher import dispatch_convolve, check_arraytypes_compatible
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.convolve)
@@ -12,15 +11,18 @@ def convolve(image,
              mode='reflect',
              cval=0.0,
              origin=0):
+    check_arraytypes_compatible(image, weights)
+
     origin = _utils._get_origin(weights.shape, origin)
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
 
     result = image.map_overlap(
-        convolve_dispatch(image),
+        dispatch_convolve,
         depth=depth,
         boundary=boundary,
         dtype=image.dtype,
+        meta=image._meta,
         weights=weights,
         mode=mode,
         cval=cval,

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
+import numpy as np
 import scipy.ndimage.filters
 
 from . import _utils

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -42,7 +42,7 @@ def numpy_convolve(*args, **kwargs):
 @convolve.register_lazy("cupy")
 def register_cupy():
     import cupy
-    import cupyx
+    import cupyx.scipy.ndimage
 
     @convolve.register(cupy.ndarray)
     def cupy_convolve(*args, **kwargs):

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -42,6 +42,7 @@ def numpy_convolve(*args, **kwargs):
 @convolve.register_lazy("cupy")
 def register_cupy():
     import cupy
+    import cupyx
 
     @convolve.register(cupy.ndarray)
     def cupy_convolve(*args, **kwargs):

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -21,7 +21,7 @@ def convolve_func(func,
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
 
     result = image.map_overlap(
-        scipy.ndimage.filters.convolve,
+        func,
         depth=depth,
         boundary=boundary,
         dtype=image.dtype,

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -39,7 +39,7 @@ def numpy_convolve(*args, **kwargs):
     return convolve_func(scipy.ndimage.filters.convolve, *args, **kwargs)
 
 
-@sizeof.register_lazy("cupy")
+@convolve.register_lazy("cupy")
 def register_cupy():
     import cupy
 

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -17,7 +17,7 @@ def _get_docstring(func):
     drop_doc_param = lambda s: not s.startswith("    output : ")  # noqa: E731
     func_doc = "" if func.__doc__ is None else func.__doc__
     cleaned_docstring = "".join([
-        l for l in split_doc_params(func_doc) if drop_doc_param(l)  # noqa: E741
+        l for l in split_doc_params(func_doc) if drop_doc_param(l)  # noqa: E741, E501
     ])
     cleaned_docstring = cleaned_docstring.replace('input', 'image')
     cleaned_docstring = cleaned_docstring.replace('labels', 'label_image')

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -17,7 +17,7 @@ def _get_docstring(func):
     drop_doc_param = lambda s: not s.startswith("    output : ")  # noqa: E731
     func_doc = "" if func.__doc__ is None else func.__doc__
     cleaned_docstring = "".join([
-        l for l in split_doc_params(func_doc) if drop_doc_param(l)
+        l for l in split_doc_params(func_doc) if drop_doc_param(l)  # noqa: E741
     ])
     cleaned_docstring = cleaned_docstring.replace('input', 'image')
     cleaned_docstring = cleaned_docstring.replace('labels', 'label_image')

--- a/dask_image/utils/__init__.py
+++ b/dask_image/utils/__init__.py
@@ -1,1 +1,0 @@
-from ._dispatcher import Dispatcher

--- a/dask_image/utils/__init__.py
+++ b/dask_image/utils/__init__.py
@@ -1,0 +1,1 @@
+from ._dispatcher import Dispatcher

--- a/dask_image/utils/_dispatcher.py
+++ b/dask_image/utils/_dispatcher.py
@@ -1,0 +1,13 @@
+from dask.utils import Dispatch
+
+class Dispatcher(Dispatch):
+    """Simple single dispatch for different dask array types."""
+
+    def __call__(self, arg, *args, **kwargs):
+        """
+        Call the corresponding method based on type of dask array.
+        """
+        # TODO: fix dask array type lookup after dask issue #6442 is resolved
+        # https://github.com/dask/dask/issues/6442
+        meth = self.dispatch(type(arg._meta))
+        return meth(arg, *args, **kwargs)

--- a/dask_image/utils/_dispatcher.py
+++ b/dask_image/utils/_dispatcher.py
@@ -1,5 +1,6 @@
 from dask.utils import Dispatch
 
+
 class Dispatcher(Dispatch):
     """Simple single dispatch for different dask array types."""
 

--- a/dask_image/utils/_dispatcher.py
+++ b/dask_image/utils/_dispatcher.py
@@ -47,15 +47,14 @@ dispatch_convolve = Dispatcher(name="dispatch_convolve")
 
 @dispatch_convolve.register(np.ndarray)
 def numpy_convolve(*args, **kwargs):
-    return scipy.ndimage.filters.convolve(*args, **kwargs)
+    return scipy.ndimage.filters.convolve
 
 
 @dispatch_convolve.register_lazy("cupy")
 def register_cupy():
     import cupy
-    import cupy.core.core
     import cupyx.scipy.ndimage
 
-    @dispatch_convolve.register(cupy.core.core.ndarray)
+    @dispatch_convolve.register(cupy.ndarray)
     def cupy_convolve(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.convolve(*args, **kwargs)
+        return cupyx.scipy.ndimage.filters.convolve

--- a/dask_image/utils/_dispatcher.py
+++ b/dask_image/utils/_dispatcher.py
@@ -3,6 +3,33 @@ import scipy.ndimage.filters
 from dask.utils import Dispatch
 
 
+def check_arraytypes_compatible(*args):
+    """Check array types are compatible.
+
+    For arrays to be compatible they must either have the same type,
+    or a dask array where the chunks match the same array type.
+
+    Examples of compatible arrays:
+    * Two (or more) numpy arrays
+    * A dask array with numpy chunks, and a numpy array
+
+    Examples of incompatible arrays:
+    * A numpy array and a cupy array
+    """
+    arraytypes = [get_type(arg) for arg in args]
+    if len(set(arraytypes)) != 1:
+        raise ValueError("Array types must be compatible.")
+
+
+def get_type(arg):
+    """Return type of arrays contained within the dask array chunks."""
+    try:
+        datatype = type(arg._meta)  # Check chunk type backing dask array
+    except AttributeError:
+        datatype = type(arg)  # For all non-dask arrays
+    return datatype
+
+
 class Dispatcher(Dispatch):
     """Simple single dispatch for different dask array types."""
 
@@ -10,23 +37,25 @@ class Dispatcher(Dispatch):
         """
         Call the corresponding method based on type of dask array.
         """
-        meth = self.dispatch(type(arg._meta))
+        datatype = get_type(arg)
+        meth = self.dispatch(datatype)
         return meth(arg, *args, **kwargs)
 
 
-convolve_dispatch = Dispatcher(name="convolve_dispatch")
+dispatch_convolve = Dispatcher(name="dispatch_convolve")
 
 
-@convolve_dispatch.register(np.ndarray)
+@dispatch_convolve.register(np.ndarray)
 def numpy_convolve(*args, **kwargs):
-    return scipy.ndimage.filters.convolve
+    return scipy.ndimage.filters.convolve(*args, **kwargs)
 
 
-@convolve_dispatch.register_lazy("cupy")
+@dispatch_convolve.register_lazy("cupy")
 def register_cupy():
     import cupy
+    import cupy.core.core
     import cupyx.scipy.ndimage
 
-    @convolve_dispatch.register(cupy.ndarray)
+    @dispatch_convolve.register(cupy.core.core.ndarray)
     def cupy_convolve(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.convolve
+        return cupyx.scipy.ndimage.filters.convolve(*args, **kwargs)


### PR DESCRIPTION
Here's the code showing how we might implement GPU support for the `convolve` function. Relevant issue: https://github.com/dask/dask-image/issues/133

Two questions:
1. If we use this pattern, how should I update the docstring wrapper? (Do I just decorate the dispatcher instance, or a method thereof?)
2. Is there a free tier including GPU support available to us for CI? Ideally we'd want to have tests for cupy arrays too.

You can try this PR out like this:
```
pip uninstall dask_image
pip install git+https://github.com/GenevieveBuckley/dask-image.git@dispatch
```

```python
import numpy as np
import cupy as cp
import dask.array as da
from dask_image.ndfilters import convolve

s = (10, 10)

# convolve with numpy
a = da.from_array(np.arange(int(np.prod(s)), dtype=np.float32).reshape(s), chunks=5)
w = np.ones(a.ndim * (3,), dtype=np.float32)
result = convolve(a, w)
result.compute()

# convolve with cupy
a = da.from_array(cp.arange(int(np.prod(s)), dtype=cp.float32).reshape(s), chunks=5)
w = cp.ones(a.ndim * (3,), dtype=cp.float32)
result = convolve(a, w)
result.compute()
```