### PR TITLE
Add GPU support for local_threshold with method='mean'

### DIFF
--- a/dask_image/dispatch/_dispatch_ndfilters.py
+++ b/dask_image/dispatch/_dispatch_ndfilters.py
@@ -295,5 +295,14 @@ def register_cupy_threshold_local_mean():
 
     @dispatch_threshold_local_mean.register(cupy.ndarray)
     def cupy_threshold_local_mean(*args, **kwargs):
-        # https://github.com/cupy/cupy/issues/3909
-        raise NotImplementedError
+        # Code snippet taken from https://github.com/cupy/cupy/issues/3909
+        my_mean = cupy.ReductionKernel(
+            'T x',  # input params
+            'T y',  # output params
+            'x',  # map
+            'a + b',  # reduce
+            'y = a / _in_ind.size()',  # An undocumented variable and a hack
+            '0',  # identity value
+            'mean'  # kernel name
+        )
+        return my_mean

--- a/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
+++ b/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
@@ -41,7 +41,6 @@ class TestSimpleImage:
                               param=1./3.)
         cupy.testing.assert_array_equal(ref, (self.image > out).compute())
 
-    @pytest.mark.skip(reason="Awaiting resolution of https://github.com/cupy/cupy/issues/3909")  # noqa: E501
     def test_threshold_local_mean(self, block_size):
         ref = cupy.array(
             [[False, False, False, False,  True],


### PR DESCRIPTION
Adds the fix suggested in https://github.com/cupy/cupy/issues/3909
