### PR TITLE
Added dask implementation of ndimage.affine_transform in new ndinterp directory.

### DIFF
--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -20,11 +20,11 @@ def numpy_affine_transform(*args, **kwargs):
 
 
 @dispatch_affine_transform.register_lazy("cupy")
-def register_cupy_convolve():
+def register_cupy_affine_transform():
     import cupy
     import cupyx.scipy.ndimage
 
-    @dispatch_convolve.register(cupy.ndarray)
+    @dispatch_affine_transform.register(cupy.ndarray)
     def cupy_affine_transform(*args, **kwargs):
 
         return cupyx.scipy.ndimage.affine_transform

--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from scipy import ndimage
+
+from ._dispatcher import Dispatcher
+
+__all__ = [
+    "dispatch_affine_transform",
+    "dispatch_asarray",
+]
+
+
+dispatch_affine_transform = Dispatcher(name="dispatch_affine_transform")
+
+# ================== affine_transform ==================
+@dispatch_affine_transform.register(np.ndarray)
+def numpy_affine_transform(*args, **kwargs):
+    return ndimage.affine_transform
+
+
+@dispatch_affine_transform.register_lazy("cupy")
+def register_cupy_convolve():
+    import cupy
+    import cupyx.scipy.ndimage
+
+    @dispatch_convolve.register(cupy.ndarray)
+    def cupy_affine_transform(*args, **kwargs):
+
+        return cupyx.scipy.ndimage.affine_transform
+
+
+dispatch_asarray = Dispatcher(name="dispatch_asarray")
+
+# ================== affine_transform ==================
+@dispatch_asarray.register(np.ndarray)
+def numpy_asarray(*args, **kwargs):
+    return np.asarray
+
+
+@dispatch_asarray.register_lazy("cupy")
+def register_cupy_asarray():
+    import cupy
+
+    @dispatch_asarray.register(cupy.ndarray)
+    def cupy_asarray(*args, **kwargs):
+
+        return cupy.asarray

--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -32,7 +32,7 @@ def register_cupy_affine_transform():
 
 dispatch_asarray = Dispatcher(name="dispatch_asarray")
 
-# ================== affine_transform ==================
+# ===================== asarray ========================
 @dispatch_asarray.register(np.ndarray)
 def numpy_asarray(*args, **kwargs):
     return np.asarray

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -129,8 +129,11 @@ def resample_chunk(chunk, image, matrix, offset, order, func_kwargs, block_info=
 
         # for some reason the behaviour becomes inconsistent with ndimage
         # if leaving out the -1 in the next line
-        rel_image_i[dim] = np.floor(rel_image_i[dim]) - order // 2 - 1
+        rel_image_i[dim] = np.floor(rel_image_i[dim]) - order // 2
         rel_image_f[dim] = np.floor(rel_image_f[dim]) - order // 2 + order
+
+        if order == 0:
+            rel_image_i[dim] -= 1
 
     # clip image coordinates to image extent
     for dim, s in zip(range(n), image_shape):

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+
+
+import numpy as np
+import dask.array as da
+from scipy import ndimage
+
+
+__all__ = [
+    "affine_transform",
+]
+
+
+def affine_transform(
+        input,
+        matrix,
+        offset=0.0,
+        output_shape=None,
+        output_chunks=None,
+        **kwargs
+):
+    """Apply an affine transform using Dask.
+    `ndimage.affine_transformation` for Dask Arrays. For every
+    output chunk, only the slice containing the relevant part
+    of the input is passed on to `ndimage.affine_transformation`.
+
+    Notes
+    -----
+        Differences to `ndimage.affine_transformation`:
+        - currently, prefiltering is not supported
+        - currently, matrix is expected to have shape (ndim,) or (ndim, ndim)
+          (because offset needs to be set for each chunk)
+        - modes 'reflect', 'mirror' and 'wrap' may yield different results
+
+        To do:
+        - optionally use cupyx.scipy.ndimage.affine_transform
+
+        Arguments equal to `ndimage.affine_transformation`,
+        except for `output_chunks`.
+
+    Parameters
+    ----------
+    input : array_like (Numpy Array, Dask Array, ...)
+        The input array.
+    matrix : array (ndim,) or (ndim, ndim)
+        Transformation matrix.
+    offset : array (ndim,)
+        Transformation offset.
+    output_shape : array (ndim,), optional
+        The size of the array to be returned.
+    output_chunks : array (ndim,), optional
+        The chunks of the output Dask Array.
+
+    Returns
+    -------
+    affine_transform : Dask Array
+        A dask array representing the transformed output
+
+    """
+
+    def resample_chunk(chunk, _matrix, _offset, _order, func_kwargs, block_info=None):
+
+        n = chunk.ndim
+        input_shape = input.shape
+        chunk_shape = chunk.shape
+
+        chunk_offset = [i[0] for i in block_info[0]['array-location']]
+
+        chunk_edges = np.array([i for i in np.ndindex(tuple([2] * n))])\
+            * np.array(chunk_shape) + np.array(chunk_offset)
+
+        rel_input_edges = np.dot(_matrix, chunk_edges.T).T + _offset
+        rel_input_i = np.min(rel_input_edges, 0)
+        rel_input_f = np.max(rel_input_edges, 0)
+
+        # expand relevant input to contain footprint of the spline kernel
+        # according to
+        #
+        # https://github.com/scipy/scipy/blob/
+        # 9c0d08d7d11fc33311a96d2ac3ad73c8f6e3df00/
+        # scipy/ndimage/src/ni_interpolation.c#L412-L419
+        #
+        # Also see https://github.com/dask/dask-image/
+        # issues/24#issuecomment-706165593
+        for dim in range(n):
+            if _order % 1:
+                start_lower = np.floor(rel_input_i[dim]) - _order // 2
+                start_upper = np.floor(rel_input_f[dim]) - _order // 2
+            else:
+                start_lower = np.floor(rel_input_i[dim] + 0.5) - _order // 2
+                start_upper = np.floor(rel_input_f[dim] + 0.5) - _order // 2
+
+            stop_upper = start_upper + _order
+            # for some reason the behaviour is different to ndimage's
+            # if leaving out the -1 in the next two lines
+            rel_input_i[dim] = start_lower - 1
+            rel_input_f[dim] = stop_upper + 1
+
+        # clip input coordinates to input image extent
+        for dim, upper in zip(range(n), input_shape):
+            rel_input_i[dim] = np.clip(rel_input_i[dim], 0, upper)
+            rel_input_f[dim] = np.clip(rel_input_f[dim], 0, upper)
+
+        rel_input_slice = tuple([slice(int(rel_input_i[dim]),
+                                       int(rel_input_f[dim]))
+                                 for dim in range(n)])
+
+        rel_input = input[rel_input_slice]
+
+        # modify offset to point into cropped input
+        # y = Mx + o
+        # coordinate substitution:
+        # y' = y - y0(min_coord_px)
+        # x' = x - x0(chunk_offset)
+        # then:
+        # y' = Mx' + o + Mx0 - y0
+        # M' = M
+        # o' = o + Mx0 - y0
+        offset_prime = _offset + np.dot(_matrix, chunk_offset) - rel_input_i
+
+        chunk = ndimage.affine_transform(rel_input,
+                                         _matrix,
+                                         offset_prime,
+                                         output_shape=chunk_shape,
+                                         order=_order,
+                                         prefilter=False,
+                                         **func_kwargs)
+
+        return chunk
+
+    if output_shape is None:
+        output_shape = input.shape
+
+    # process kwargs
+
+    # set default order to 1, warn if different
+    if 'order' in kwargs:
+        order = kwargs['order']
+        del kwargs['order']
+        if order > 1:
+            UserWarning('Currently, for order > 1 the output of'
+                        '`dask_image.ndinterp.affine_transform` can differ'
+                        'from that of `ndimage.affine_transform`')
+    else:
+        order = 1
+
+    # prefilter is not yet supported
+    if 'prefilter' in kwargs:
+        if kwargs['prefilter'] and order > 1:
+            UserWarning('Currently, `dask_image.ndinterp.affine_transform`'
+                        'does not support `prefilter=True`')
+        del kwargs['prefilter']
+
+    transformed = da.zeros(output_shape,
+                           dtype=input.dtype,
+                           chunks=output_chunks)
+
+    transformed = transformed.map_blocks(resample_chunk,
+                                         dtype=input.dtype,
+                                         _matrix=matrix,
+                                         _offset=offset,
+                                         _order=order,
+                                         func_kwargs=kwargs,
+                                         )
+
+    return transformed

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -28,6 +28,8 @@ def affine_transform(
     -----
         Differences to `ndimage.affine_transformation`:
         - currently, prefiltering is not supported
+          (affecting the output in case of interpolation `order > 1`)
+        - default order is 1
         - currently, matrix is expected to have shape (ndim,) or (ndim, ndim)
           (because offset needs to be set for each chunk)
         - modes 'reflect', 'mirror' and 'wrap' may yield different results
@@ -58,76 +60,6 @@ def affine_transform(
 
     """
 
-    def resample_chunk(chunk, _matrix, _offset, _order, func_kwargs, block_info=None):
-
-        n = chunk.ndim
-        input_shape = input.shape
-        chunk_shape = chunk.shape
-
-        chunk_offset = [i[0] for i in block_info[0]['array-location']]
-
-        chunk_edges = np.array([i for i in np.ndindex(tuple([2] * n))])\
-            * np.array(chunk_shape) + np.array(chunk_offset)
-
-        rel_input_edges = np.dot(_matrix, chunk_edges.T).T + _offset
-        rel_input_i = np.min(rel_input_edges, 0)
-        rel_input_f = np.max(rel_input_edges, 0)
-
-        # expand relevant input to contain footprint of the spline kernel
-        # according to
-        #
-        # https://github.com/scipy/scipy/blob/
-        # 9c0d08d7d11fc33311a96d2ac3ad73c8f6e3df00/
-        # scipy/ndimage/src/ni_interpolation.c#L412-L419
-        #
-        # Also see https://github.com/dask/dask-image/
-        # issues/24#issuecomment-706165593
-        for dim in range(n):
-            if _order % 1:
-                start_lower = np.floor(rel_input_i[dim]) - _order // 2
-                start_upper = np.floor(rel_input_f[dim]) - _order // 2
-            else:
-                start_lower = np.floor(rel_input_i[dim] + 0.5) - _order // 2
-                start_upper = np.floor(rel_input_f[dim] + 0.5) - _order // 2
-
-            stop_upper = start_upper + _order
-            # for some reason the behaviour is different to ndimage's
-            # if leaving out the -1 in the next two lines
-            rel_input_i[dim] = start_lower - 1
-            rel_input_f[dim] = stop_upper + 1
-
-        # clip input coordinates to input image extent
-        for dim, upper in zip(range(n), input_shape):
-            rel_input_i[dim] = np.clip(rel_input_i[dim], 0, upper)
-            rel_input_f[dim] = np.clip(rel_input_f[dim], 0, upper)
-
-        rel_input_slice = tuple([slice(int(rel_input_i[dim]),
-                                       int(rel_input_f[dim]))
-                                 for dim in range(n)])
-
-        rel_input = input[rel_input_slice]
-
-        # modify offset to point into cropped input
-        # y = Mx + o
-        # coordinate substitution:
-        # y' = y - y0(min_coord_px)
-        # x' = x - x0(chunk_offset)
-        # then:
-        # y' = Mx' + o + Mx0 - y0
-        # M' = M
-        # o' = o + Mx0 - y0
-        offset_prime = _offset + np.dot(_matrix, chunk_offset) - rel_input_i
-
-        chunk = ndimage.affine_transform(rel_input,
-                                         _matrix,
-                                         offset_prime,
-                                         output_shape=chunk_shape,
-                                         order=_order,
-                                         prefilter=False,
-                                         **func_kwargs)
-
-        return chunk
-
     if output_shape is None:
         output_shape = input.shape
 
@@ -157,10 +89,83 @@ def affine_transform(
 
     transformed = transformed.map_blocks(resample_chunk,
                                          dtype=input.dtype,
-                                         _matrix=matrix,
-                                         _offset=offset,
-                                         _order=order,
+                                         input=input,
+                                         matrix=matrix,
+                                         offset=offset,
+                                         order=order,
                                          func_kwargs=kwargs,
                                          )
 
     return transformed
+
+
+def resample_chunk(chunk, input, matrix, offset, order, func_kwargs, block_info=None):
+    """Resample a given chunk, used by `affine_transform`."""
+
+    n = chunk.ndim
+    input_shape = input.shape
+    chunk_shape = chunk.shape
+
+    chunk_offset = [i[0] for i in block_info[0]['array-location']]
+
+    chunk_edges = np.array([i for i in np.ndindex(tuple([2] * n))])\
+        * np.array(chunk_shape) + np.array(chunk_offset)
+
+    rel_input_edges = np.dot(matrix, chunk_edges.T).T + offset
+    rel_input_i = np.min(rel_input_edges, 0)
+    rel_input_f = np.max(rel_input_edges, 0)
+
+    # expand relevant input to contain footprint of the spline kernel
+    # according to
+    #
+    # https://github.com/scipy/scipy/blob/
+    # 9c0d08d7d11fc33311a96d2ac3ad73c8f6e3df00/
+    # scipy/ndimage/src/ni_interpolation.c#L412-L419
+    #
+    # Also see https://github.com/dask/dask-image/
+    # issues/24#issuecomment-706165593
+    for dim in range(n):
+        if order % 1:
+            start_lower = np.floor(rel_input_i[dim]) - order // 2
+            start_upper = np.floor(rel_input_f[dim]) - order // 2
+        else:
+            start_lower = np.floor(rel_input_i[dim] + 0.5) - order // 2
+            start_upper = np.floor(rel_input_f[dim] + 0.5) - order // 2
+
+        stop_upper = start_upper + order
+        # for some reason the behaviour is different to ndimage's
+        # if leaving out the -1 in the next two lines
+        rel_input_i[dim] = start_lower - 1
+        rel_input_f[dim] = stop_upper + 1
+
+    # clip input coordinates to input image extent
+    for dim, upper in zip(range(n), input_shape):
+        rel_input_i[dim] = np.clip(rel_input_i[dim], 0, upper)
+        rel_input_f[dim] = np.clip(rel_input_f[dim], 0, upper)
+
+    rel_input_slice = tuple([slice(int(rel_input_i[dim]),
+                                   int(rel_input_f[dim]))
+                             for dim in range(n)])
+
+    rel_input = input[rel_input_slice]
+
+    # modify offset to point into cropped input
+    # y = Mx + o
+    # coordinate substitution:
+    # y' = y - y0(min_coord_px)
+    # x' = x - x0(chunk_offset)
+    # then:
+    # y' = Mx' + o + Mx0 - y0
+    # M' = M
+    # o' = o + Mx0 - y0
+    offset_prime = offset + np.dot(matrix, chunk_offset) - rel_input_i
+
+    chunk = ndimage.affine_transform(rel_input,
+                                     matrix,
+                                     offset_prime,
+                                     output_shape=chunk_shape,
+                                     order=order,
+                                     prefilter=False,
+                                     **func_kwargs)
+
+    return chunk

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -32,9 +32,7 @@ def affine_transform(
         - currently, prefiltering is not supported
           (affecting the output in case of interpolation `order > 1`)
         - default order is 1
-        - currently, matrix is expected to have shape (ndim,) or (ndim, ndim)
-          (because offset needs to be set for each chunk)
-        - modes 'reflect', 'mirror' and 'wrap' may yield different results
+        - modes 'reflect', 'mirror' and 'wrap' are not supported
 
         To do:
         - optionally use cupyx.scipy.ndimage.affine_transform
@@ -46,7 +44,7 @@ def affine_transform(
     ----------
     image : array_like (Numpy Array, Dask Array, ...)
         The image array.
-    matrix : array (ndim,) or (ndim, ndim)
+    matrix : array (ndim,), (ndim, ndim), (ndim, ndim+1) or (ndim+1, ndim+1)
         Transformation matrix.
     offset : array (ndim,)
         Transformation offset.
@@ -110,6 +108,11 @@ def affine_transform(
                           'lead to the output containing more blur than with'
                           'prefiltering.', UserWarning)
         del kwargs['prefilter']
+
+    if 'mode' in kwargs:
+        if kwargs['mode'] in ['wrap', 'reflect', 'mirror']:
+            raise(NotImplementedError("Mode %s is not currently supported."
+                                      % kwargs['mode']))
 
     transformed = da.zeros(output_shape,
                            dtype=image.dtype,

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -123,6 +123,10 @@ def affine_transform(
                            dtype=image.dtype,
                            chunks=output_chunks)
 
+    # define output array type
+    meta = dispatch_asarray(image)([]).astype(image.dtype)
+
+    # map affine_transform onto array
     transformed = transformed.map_blocks(resample_chunk,
                                          dtype=image.dtype,
                                          image=image,
@@ -130,6 +134,7 @@ def affine_transform(
                                          offset=offset,
                                          order=order,
                                          func_kwargs=kwargs,
+                                         meta=meta
                                          )
 
     return transformed
@@ -203,7 +208,7 @@ def resample_chunk(chunk, image, matrix, offset, order, func_kwargs, block_info=
 
     chunk = affine_transform_method(rel_image,
                                     asarray_method(matrix),
-                                    asarray_method(offset_prime),
+                                    offset_prime,
                                     output_shape=chunk_shape,
                                     order=order,
                                     prefilter=False,

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -97,13 +97,7 @@ def affine_transform(
     # these lines were copied and adapted from `ndimage.affine_transform`
     if (matrix.ndim == 2 and matrix.shape[1] == image.ndim + 1 and
             (matrix.shape[0] in [image.ndim, image.ndim + 1])):
-        # if matrix.shape[0] == image.ndim + 1:
-        #     exptd = [0] * image.ndim + [1]
-        #     if not np.all(matrix[image.ndim] == exptd):
-        #         msg = ('Expected homogeneous transformation matrix with '
-        #                'shape %s for image shape %s, but bottom row was '
-        #                'not equal to %s' % (matrix.shape, image.shape, exptd))
-        #         raise ValueError(msg)
+
         # assume input is homogeneous coordinate transformation matrix
         offset = matrix[:image.ndim, image.ndim]
         matrix = matrix[:image.ndim, :image.ndim]

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -26,10 +26,11 @@ def affine_transform(
         output_chunks=None,
         **kwargs
 ):
-    """Apply an affine transform using Dask.
-    `ndimage.affine_transformation` for Dask Arrays. For every
+    """Apply an affine transform using Dask. For every
     output chunk, only the slice containing the relevant part
-    of the image is passed on to `ndimage.affine_transformation`.
+    of the image is processed. Chunkwise processing is performed
+    either using `ndimage.affine_transform` or
+    `cupyx.scipy.ndimage.affine_transform`, depending on the input type.
 
     Notes
     -----
@@ -39,15 +40,12 @@ def affine_transform(
         - default order is 1
         - modes 'reflect', 'mirror' and 'wrap' are not supported
 
-        To do:
-        - optionally use cupyx.scipy.ndimage.affine_transform
-
         Arguments equal to `ndimage.affine_transformation`,
         except for `output_chunks`.
 
     Parameters
     ----------
-    image : array_like (Numpy Array, Dask Array, ...)
+    image : array_like (Numpy Array, Cupy Array, Dask Array...)
         The image array.
     matrix : array (ndim,), (ndim, ndim), (ndim, ndim+1) or (ndim+1, ndim+1)
         Transformation matrix.
@@ -123,7 +121,7 @@ def affine_transform(
                            dtype=image.dtype,
                            chunks=output_chunks)
 
-    # define output array type
+    # define meta array to inform dask of the output chunk type
     meta = dispatch_asarray(image)([]).astype(image.dtype)
 
     # map affine_transform onto array

--- a/docs/coverage.rst
+++ b/docs/coverage.rst
@@ -16,7 +16,7 @@ This table shows which SciPy ndimage functions are supported by dask-image.
      - dask-image
    * - ``affine_transform``
      - ✓
-     - 
+     - ✓
    * - ``binary_closing``
      - ✓
      - ✓

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ test_requirements = [
     "flake8 >=3.4.1",
     "pytest >=3.0.5",
     "pytest-flake8 >=0.8.1",
+    "pytest-timeout >=1.0.0",
     "tifffile >=2018.10.18",
 ]
 

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+import dask_image.ndinterp as da_ndinterp
+
+import numpy as np
+import dask.array as da
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4])
+@pytest.mark.parametrize("interp_order", [0, 1, 3])
+def test_affine_transformation(n, interp_order):
+    """
+    Compare the outputs of `ndimage.affine_transformation`
+    and `dask_image.ndinterp.affine_transformation`.
+
+    Notes
+    -----
+        Currently, prefilter is disabled and therefore the output
+        of `dask_image.ndinterp.affine_transformation` is compared
+        to `prefilter=False`.
+    """
+
+    # define test image
+    a = 25
+    im = np.random.random([a] * n)
+
+    # transform into dask array
+    chunksize = [16] * n
+    dim = da.from_array(im, chunks=chunksize)
+
+    # define (random) transformation
+    matrix = np.eye(n) + (np.random.random((n, n)) - 0.5) / 5.
+    offset = (np.random.random(n) - 0.5) / 5. * np.array(im.shape)
+
+    # define resampling options
+    output_shape = [int(a / 2)] * n
+    output_chunks = [16] * n
+
+    from scipy import ndimage
+    # transform with scipy
+    im_t_scipy = ndimage.affine_transform(im, matrix, offset,
+                                          output_shape=output_shape,
+                                          order=interp_order,
+                                          prefilter=False)
+
+    # transform with dask-image
+    im_t_dask = da_ndinterp.affine_transform(dim, matrix, offset,
+                                             output_shape=output_shape,
+                                             output_chunks=output_chunks,
+                                             order=interp_order)
+    im_t_dask_computed = im_t_dask.compute()
+
+    print(im_t_scipy, im_t_dask_computed)
+    assert np.allclose(im_t_scipy, im_t_dask_computed)
+


### PR DESCRIPTION
This PR aims to add `dask-image` support for `scipy.ndimage.affine_transform` (https://github.com/dask/dask-image/issues/24).

Code changes:
  - added new directory for ndinterp
  - included `affine_transform` implementation in `__init__.py`
  - added test that compares output to scipy for some test cases

Differences to `ndimage.affine_transformation`:
  - currently, prefiltering is not supported (changing the output in case of interpolation `order > 1`)
  - default order is 1
  - currently, matrix is expected to have shape (ndim,) or (ndim, ndim) (because offset needs to be set for each chunk)
  - modes 'reflect', 'mirror' and 'wrap' may yield different results

This implementation includes suggestions by @grlee77 about how to provide the correct spline order footprint.

Also, as @grlee77 pointed out, dask leveraged prefiltering could be added as it consists of preprocessing the input array with `ndimage.spline_filter`, which is a separable filter that requires the full array along a given axis (see https://github.com/dask/dask-image/issues/24#issuecomment-706165593). However, even if implemented it might make sense to prevent this prefiltering from being executed by default, as the chunking it requires would (in my understanding) lead to the input array being computed entirely (or at least in parts that are much larger than the relevant input blocks).