### PR TITLE
Fix imread tests and cover warnings

### DIFF
--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -69,17 +69,14 @@ def test_tiff_imread(tmpdir, seed, nframes, dtype, shape, runtime_warning):
 
     a = np.random.uniform(low=low, high=high, size=shape).astype(dtype)
 
+    fn_pattern = str(dirpth.join("test_%s.tiff"))
+    for i in range(shape[0]):
+        with tifffile.TiffWriter(fn_pattern % i) as fh:
+            fh.save(a[i])
+
     if shape[0] == 1:
-        fn = str(dirpth.join("test.tiff"))
-        with tifffile.TiffWriter(fn) as fh:
-            for i in range(len(a)):
-                fh.save(a[i])
+        fn = fn_pattern % 0
     else:
-        fn_pattern = str(dirpth.join("test_%s.tiff"))
-        for i in range(shape[0]):
-            fn_i = fn_pattern % i
-            with tifffile.TiffWriter(fn_i) as fh:
-                fh.save(a[i])
         fn = fn_pattern % '*'
 
     with pytest.warns(None if runtime_warning is None


### PR DESCRIPTION
This PR intends to fix currently failing imread tests https://github.com/dask/dask-image/issues/160.

Locally, I found that the problem with the current test `test_imread.test_core.py::test_tiff_imread` was that in case of `shape[0] > 1`, only one image file was written and read. I fixed this by changing

```python
    fn = str(dirpth.join("test.tiff"))
    with tifffile.TiffWriter(fn) as fh:
        for i in range(len(a)):
            fh.save(a[i])
```

into
```python
    fn_pattern = str(dirpth.join("test_%s.tiff"))
    for i in range(shape[0]):
        with tifffile.TiffWriter(fn_pattern % i) as fh:
            fh.save(a[i])

    if shape[0] == 1:
        fn = fn_pattern % 0
    else:
        fn = fn_pattern % '*'
```
(edited)

Splitting up the cases `shape[0]==1` and `>1` seemed necessary because `pims.open` doesn't seem to find single files using the wildcard `*`.

This fixes my tests locally, though I'm not quite sure yet why the CI currently passes for py36 (as seen e.g. here https://github.com/dask/dask-image/pull/159).

Aiming to have this merged before submitting the PR addressing the proposed `imread` change in https://github.com/dask/dask-image/issues/161.
