### PR TITLE
Fix imread tests (add `contiguous=True` when saving test data with tifffile)

### DIFF
--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -36,17 +36,17 @@ def test_errs_imread(err_type, nframes):
     ]
 )
 @pytest.mark.parametrize(
-    "nframes, shape",
+    "nframes, shape, runtime_warning",
     [
-        (1, (1, 4, 3)),
-        (-1, (1, 4, 3)),
-        (3, (1, 4, 3)),
-        (1, (5, 4, 3)),
-        (2, (5, 4, 3)),
-        (1, (10, 5, 4, 3)),
-        (5, (10, 5, 4, 3)),
-        (10, (10, 5, 4, 3)),
-        (-1, (10, 5, 4, 3)),
+        (1, (1, 4, 3), None),
+        (-1, (1, 4, 3), None),
+        (3, (1, 4, 3), "`nframes` larger than"),
+        (1, (5, 4, 3), None),
+        (2, (5, 4, 3), "`nframes` does not nicely divide"),
+        (1, (10, 5, 4, 3), None),
+        (5, (10, 5, 4, 3), None),
+        (10, (10, 5, 4, 3), None),
+        (-1, (10, 5, 4, 3), None),
     ]
 )
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ def test_errs_imread(err_type, nframes):
         np.float32,
     ]
 )
-def test_tiff_imread(tmpdir, seed, nframes, shape, dtype):
+def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype):
     np.random.seed(seed)
 
     dirpth = tmpdir.mkdir("test_imread")
@@ -74,7 +74,9 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, dtype):
         for i in range(len(a)):
             fh.save(a[i], contiguous=True)
 
-    d = dask_image.imread.imread(fn, nframes=nframes)
+    with pytest.warns(None if runtime_warning is None
+                      else RuntimeWarning, match=runtime_warning):
+        d = dask_image.imread.imread(fn, nframes=nframes)
 
     if nframes == -1:
         nframes = shape[0]

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -72,7 +72,7 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, dtype):
     fn = str(dirpth.join("test.tiff"))
     with tifffile.TiffWriter(fn) as fh:
         for i in range(len(a)):
-            fh.save(a[i])
+            fh.save(a[i], contiguous=True)
 
     d = dask_image.imread.imread(fn, nframes=nframes)
 


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/160
Related work: https://github.com/dask/dask-image/pull/162

It seems there was a change introduced between tifffile version 2020.8.25 and 2020.9.3 that led to some failing tests for dask-image imread. We pin almost everything in our test environments, but we don't seem to have pinned tifffile. 

Here's the difference between those two versions of tifffile (there is a breaking change in there): https://github.com/cgohlke/tifffile/compare/v2020.8.25...v2020.9.3 Specifically, there was a change to the default argument of the `contiguous` keyword argument when saving data with tifffile.

We can explicitly specify `contiguous=True` when we write our tifffile example data for the tests. That fixes the problem, no matter what version of tifffile is used in our test environment.