### PR TITLE
Update dependencies in RTD environment

### DIFF
--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -4,12 +4,12 @@ channels:
   - conda-forge
 
 dependencies:
-  - pip==18.0
-  - wheel==0.31.1
-  - sphinx==1.7.5
-  - dask-sphinx-theme==1.1.0
-  - dask==0.16.1
-  - numpy==1.11.3
+  - pip==19.0.1
+  - wheel==0.32.3
+  - sphinx==3.2.1
+  - dask-sphinx-theme==1.3.5
+  - dask==2.8.1
+  - numpy==1.15.4
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - pip==19.0.1
-  - wheel==0.32.3
+  - pip==20.2.4
+  - wheel==0.35.1
   - sphinx==3.2.1
   - dask-sphinx-theme==1.3.5
   - dask==2.8.1


### PR DESCRIPTION
ReadTheDocs builds recently started failing. This seems to be due to a `pip` option being passed that the version of `pip` we use here doesn't understand. In an attempt to fix this issue, try modernizing our dependencies here.

https://readthedocs.org/projects/dask-image/builds/12159489/