### PR TITLE
DOCUMENTATION: Add section Talks and Slides #163

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -74,3 +74,12 @@ Good places to start include:
 
 * The dask-image API documentation: http://image.dask.org/en/latest/api.html
 * The documentation on working with dask arrays: http://docs.dask.org/en/latest/array.html
+
+
+Talks and Slides
+----------------
+
+Here are some talks and slides that you can watch to learn dask-image:
+
+- https://github.com/GenevieveBuckley/dask-image-talk-2020
+- https://github.com/jakirkham/scipy2019

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -81,5 +81,12 @@ Talks and Slides
 
 Here are some talks and slides that you can watch to learn dask-image:
 
-- https://github.com/GenevieveBuckley/dask-image-talk-2020
-- https://github.com/jakirkham/scipy2019
+- 2020, Genevieve Buckley's talk at PyConAU and SciPy Japan
+
+  - `Watch the talk <https://www.youtube.com/watch?v=MpjgzNeISeI&list=PLs4CJRBY5F1IEFq-wumrBDRCu2EqkpY-R&index=2>`_
+  - `See the slides <https://genevievebuckley.github.io/dask-image-talk-2020>`_
+
+- 2019, John Kirkham's SciPy talk
+
+  - `Watch the talk <https://www.youtube.com/watch?v=XGUS174vvLs>`_
+  - `See the slides <https://nbviewer.ipython.org/format/slides/github/jakirkham/scipy2019/blob/master/slides.ipynb#/>`_


### PR DESCRIPTION
This is a sprint contribution in ScipyJapan2020 (#163).
I added a page to the docs with links to youtube talks and slides from previous presentations.
Thank you for reading.