### PR TITLE
FIX scipy LooseVersion for sum_labels check

### DIFF
--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -113,7 +113,7 @@ def test_center_of_mass(datatype):
 )
 def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     # early scipy version uses a different name sum insted of sum_labels.
-    if funcname == 'sum_labels' and scipy.__version__ < LooseVersion('1.5.0'):
+    if funcname == 'sum_labels' and scipy.__version__ < LooseVersion('1.6.0'):
         scipy_funcname = 'sum'
     else:
         scipy_funcname = funcname


### PR DESCRIPTION
FIX `LooseVersion` of #172.
This is a sprint contribution in ScipyJapan2020 (#163) .
As you can see here. `sum_labels` will added in scipy 1.6.0.
Sorry for mistake.
![image](https://user-images.githubusercontent.com/7513610/97830484-7a17e280-1d10-11eb-873f-b73043236c8f.png)
https://github.com/scipy/scipy/pull/12242