### PR TITLE
affine_transform: Remove inconsistencies with ndimage implementation.

### DIFF
--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 def affine_transform(
         image,
         matrix,
-        offset=None,
+        offset=0.0,
         output_shape=None,
         order=1,
         output_chunks=None,
@@ -54,16 +54,18 @@ def affine_transform(
         The image array.
     matrix : array (ndim,), (ndim, ndim), (ndim, ndim+1) or (ndim+1, ndim+1)
         Transformation matrix.
-    offset : array (ndim,)
-        Transformation offset.
-    output_shape : array (ndim,), optional
-        The size of the array to be returned.
+    offset : float or sequence, optional
+        The offset into the array where the transform is applied. If a float,
+        `offset` is the same for each axis. If a sequence, `offset` should
+        contain one value for each axis.
+    output_shape : tuple of ints, optional
+        The shape of the array to be returned.
     order : int, optional
         The order of the spline interpolation. Note that for order>1
         scipy's affine_transform applies prefiltering, which is not
         yet supported and skipped in this implementation.
-    output_chunks : array (ndim,), optional
-        The chunks of the output Dask Array.
+    output_chunks : tuple of ints, optional
+        The shape of the chunks of the output Dask Array.
 
     Returns
     -------
@@ -123,7 +125,8 @@ def affine_transform(
     image_shape = image.shape
 
     # calculate output array properties
-    normalized_chunks = da.core.normalize_chunks(output_chunks, output_shape)
+    normalized_chunks = da.core.normalize_chunks(output_chunks,
+                                                 tuple(output_shape))
     block_indices = product(*(range(len(bds)) for bds in normalized_chunks))
     block_offsets = [np.cumsum((0,) + bds[:-1]) for bds in normalized_chunks]
 
@@ -223,7 +226,7 @@ def affine_transform(
 
     transformed = da.Array(graph,
                            output_name,
-                           shape=output_shape,
+                           shape=tuple(output_shape),
                            # chunks=output_chunks,
                            chunks=normalized_chunks,
                            meta=meta)

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -117,12 +117,6 @@ def test_affine_transform_cupy(n,
                                random_seed):
     cupy = pytest.importorskip("cupy", minversion="6.0.0")
 
-    # somehow, these lines are required for the first parametrized
-    # test to succeed
-    from dask_image.dispatch._dispatch_ndinterp import (
-        dispatch_affine_transform)
-    dispatch_affine_transform(cupy.asarray([]))
-
     kwargs = dict()
     kwargs['n'] = n
     kwargs['input_output_shape_per_dim'] = input_output_shape_per_dim

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -180,6 +180,14 @@ def test_affine_transform_numpy_input():
     assert (image == image_t).min()
 
 
+def test_affine_transform_minimal_input():
+
+    image = np.ones((3, 3))
+    image_t = da_ndinterp.affine_transform(np.ones((3, 3)), np.eye(2))
+
+    assert image_t.shape == image.shape
+
+
 def test_affine_transform_type_consistency():
 
     image = da.ones((3, 3))

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -115,15 +115,13 @@ def test_affine_transform_cupy(n,
                                interp_order,
                                input_output_chunksize_per_dim,
                                random_seed):
-
-    pytest.importorskip("cupy", minversion="6.0.0")
+    cupy = pytest.importorskip("cupy", minversion="6.0.0")
 
     # somehow, these lines are required for the first parametrized
     # test to succeed
-    import cupy as cp
     from dask_image.dispatch._dispatch_ndinterp import (
         dispatch_affine_transform)
-    dispatch_affine_transform(cp.asarray([]))
+    dispatch_affine_transform(cupy.asarray([]))
 
     kwargs = dict()
     kwargs['n'] = n
@@ -197,15 +195,15 @@ def test_affine_transform_type_consistency():
     assert isinstance(image[0, 0].compute(), type(image_t[0, 0].compute()))
 
 
+@pytest.mark.cupy
 def test_affine_transform_type_consistency_gpu():
 
-    pytest.importorskip("cupy", minversion="6.0.0")
+    cupy = pytest.importorskip("cupy", minversion="6.0.0")
 
     image = da.ones((3, 3))
     image_t = da_ndinterp.affine_transform(image, np.eye(2), [0, 0])
 
-    import cupy as cp
-    image.map_blocks(cp.asarray)
+    image.map_blocks(cupy.asarray)
 
     assert isinstance(image, type(image_t))
     assert isinstance(image[0, 0].compute(), type(image_t[0, 0].compute()))
@@ -244,17 +242,17 @@ def test_affine_transform_large_input_small_output_cpu():
     image_t[0, 0, 0].compute()
 
 
+@pytest.mark.cupy
 @pytest.mark.timeout(15)
 def test_affine_transform_large_input_small_output_gpu():
     """
     Make sure input array does not need to be computed entirely
     """
-    pytest.importorskip("cupy", minversion="6.0.0")
+    cupy = pytest.importorskip("cupy", minversion="6.0.0")
 
     # this array would occupy more than 24GB on a GPU
     image = da.random.random([2000] * 3, chunks=(50, 50, 50))
-    import cupy as cp
-    image.map_blocks(cp.asarray)
+    image.map_blocks(cupy.asarray)
 
     image_t = da_ndinterp.affine_transform(image, np.eye(3), [0, 0, 0],
                                            output_chunks=[1, 1, 1],


### PR DESCRIPTION
As reported by @martinschorb in https://github.com/dask/dask-image/issues/204, there are some inconsistencies in `dask_image.ndinterp.affine_transform` with respect to the `ndimage` implementation.

This PR
1) fixes the behaviour when not providing an offset argument and adds a test for this.
2) adapts the function API to expect tuples of ints for the shape related parameters, just as the downstream `scipy` implementation does. As @martinschorb points out, the `scipy` implementation also works when providing `output_shape` as a `ndarray`, so I now explicitly perform a conversion into tuple within the function to also allow for this (please object if this doesn't make sense).

I don't see reasons for why the inconsistencies had been there in the first place and assume I had simply not been careful enough during the implementation. Also, there should be no backwards compatibility problem introduced by this PR.