### PR TITLE
Fix _meta type and dtype for ndmorph functions

### DIFF
--- a/dask_image/ndmorph/__init__.py
+++ b/dask_image/ndmorph/__init__.py
@@ -38,6 +38,7 @@ def binary_closing(image,
     result = binary_erosion(
         result, structure=structure, iterations=iterations, origin=origin
     )
+    result._meta = image._meta.astype(bool)
 
     return result
 
@@ -62,6 +63,7 @@ def binary_dilation(image,
         brute_force=brute_force,
         border_value=border_value
     )
+    result._meta = image._meta.astype(bool)
 
     return result
 
@@ -86,6 +88,7 @@ def binary_erosion(image,
         brute_force=brute_force,
         border_value=border_value
     )
+    result._meta = image._meta.astype(bool)
 
     return result
 
@@ -108,5 +111,6 @@ def binary_opening(image,
     result = binary_dilation(
         result, structure=structure, iterations=iterations, origin=origin
     )
+    result._meta = image._meta.astype(bool)
 
     return result

--- a/tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py
@@ -28,4 +28,9 @@ def array():
 def test_cupy_ndmorph(array, func):
     """Test convolve & correlate filters with cupy input arrays."""
     result = func(array)
-    result.compute()
+    assert result.dtype == bool
+    assert result._meta.dtype == bool
+    assert isinstance(result._meta, cupy.ndarray)
+    computed = result.compute()
+    assert computed.dtype == bool
+    assert isinstance(computed, cupy.ndarray)


### PR DESCRIPTION
This PR fixes a small bug where we weren't setting the dask array `_meta` attribute correctly.

Here are the cupy local test results (python 3.8, cupy 9.0.0b3, dask-image main)
```
(dask-image-dev) genevieve@genevieve-G5-5500:~/GitHub/dask-image$ conda list | grep cupy
cupy                      9.0.0b3          py38hecb4491_0    conda-forge/label/cupy_rc
(dask-image-dev) genevieve@genevieve-G5-5500:~/GitHub/dask-image$ pytest -v tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py 
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.8.8, pytest-5.3.1, py-1.10.0, pluggy-0.13.1 -- /home/genevieve/anaconda3/envs/dask-image-dev/bin/python
cachedir: .pytest_cache
rootdir: /home/genevieve/GitHub/dask-image, inifile: pytest.ini
plugins: flake8-1.0.4
collected 4 items                                                                                                                                                                

tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py::test_cupy_ndmorph[binary_closing] PASSED                                                                          [ 25%]
tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py::test_cupy_ndmorph[binary_dilation] PASSED                                                                         [ 50%]
tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py::test_cupy_ndmorph[binary_erosion] PASSED                                                                          [ 75%]
tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py::test_cupy_ndmorph[binary_opening] PASSED                                                                          [100%]
========================================================================= 4 passed, 3 warnings in 0.98s ==========================================================================
```
