### PR TITLE
Simplify setting meta attribute for ndmorph functions

### DIFF
--- a/dask_image/ndmorph/__init__.py
+++ b/dask_image/ndmorph/__init__.py
@@ -38,7 +38,6 @@ def binary_closing(image,
     result = binary_erosion(
         result, structure=structure, iterations=iterations, origin=origin
     )
-    result._meta = image._meta.astype(bool)
 
     return result
 
@@ -63,7 +62,6 @@ def binary_dilation(image,
         brute_force=brute_force,
         border_value=border_value
     )
-    result._meta = image._meta.astype(bool)
 
     return result
 
@@ -88,7 +86,6 @@ def binary_erosion(image,
         brute_force=brute_force,
         border_value=border_value
     )
-    result._meta = image._meta.astype(bool)
 
     return result
 
@@ -111,6 +108,5 @@ def binary_opening(image,
     result = binary_dilation(
         result, structure=structure, iterations=iterations, origin=origin
     )
-    result._meta = image._meta.astype(bool)
 
     return result

--- a/dask_image/ndmorph/_ops.py
+++ b/dask_image/ndmorph/_ops.py
@@ -37,5 +37,6 @@ def _binary_op(func,
             **kwargs
         )
         result = dask.array.where(mask, iter_result, result)
+        result._meta = image._meta.astype(bool)
 
     return result


### PR DESCRIPTION
Marvin has pointed out a much [simpler solution here](https://github.com/dask/dask-image/pull/206#issuecomment-823902083) for https://github.com/dask/dask-image/pull/206

This is probably what I should have done in the first place.
