### PR TITLE
Add spline_filter and spline_filter1d

### DIFF
--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -30,6 +30,44 @@ def register_cupy_affine_transform():
         return cupyx.scipy.ndimage.affine_transform
 
 
+dispatch_spline_filter = Dispatcher(name="dispatch_spline_filter")
+
+# ================== spline_filter ==================
+@dispatch_spline_filter.register(np.ndarray)
+def numpy_spline_filter(*args, **kwargs):
+    return ndimage.spline_filter
+
+
+@dispatch_spline_filter.register_lazy("cupy")
+def register_cupy_spline_filter():
+    import cupy
+    import cupyx.scipy.ndimage
+
+    @dispatch_affine_transform.register(cupy.ndarray)
+    def cupy_spline_filter(*args, **kwargs):
+
+        return cupyx.scipy.ndimage.spline_filter
+
+
+dispatch_spline_filter1d = Dispatcher(name="dispatch_spline_filter1d")
+
+# ================== spline_filter1d ==================
+@dispatch_spline_filter1d.register(np.ndarray)
+def numpy_spline_filter1d(*args, **kwargs):
+    return ndimage.spline_filter1d
+
+
+@dispatch_spline_filter1d.register_lazy("cupy")
+def register_cupy_spline_filter1d():
+    import cupy
+    import cupyx.scipy.ndimage
+
+    @dispatch_affine_transform.register(cupy.ndarray)
+    def cupy_spline_filter1d(*args, **kwargs):
+
+        return cupyx.scipy.ndimage.spline_filter1d
+
+
 dispatch_asarray = Dispatcher(name="dispatch_asarray")
 
 # ===================== asarray ========================

--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -43,7 +43,7 @@ def register_cupy_spline_filter():
     import cupy
     import cupyx.scipy.ndimage
 
-    @dispatch_affine_transform.register(cupy.ndarray)
+    @dispatch_spline_filter.register(cupy.ndarray)
     def cupy_spline_filter(*args, **kwargs):
 
         return cupyx.scipy.ndimage.spline_filter
@@ -62,7 +62,7 @@ def register_cupy_spline_filter1d():
     import cupy
     import cupyx.scipy.ndimage
 
-    @dispatch_affine_transform.register(cupy.ndarray)
+    @dispatch_spline_filter1d.register(cupy.ndarray)
     def cupy_spline_filter1d(*args, **kwargs):
 
         return cupyx.scipy.ndimage.spline_filter1d

--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -13,6 +13,7 @@ __all__ = [
 
 dispatch_affine_transform = Dispatcher(name="dispatch_affine_transform")
 
+
 # ================== affine_transform ==================
 @dispatch_affine_transform.register(np.ndarray)
 def numpy_affine_transform(*args, **kwargs):
@@ -31,6 +32,7 @@ def register_cupy_affine_transform():
 
 
 dispatch_spline_filter = Dispatcher(name="dispatch_spline_filter")
+
 
 # ================== spline_filter ==================
 @dispatch_spline_filter.register(np.ndarray)
@@ -51,6 +53,7 @@ def register_cupy_spline_filter():
 
 dispatch_spline_filter1d = Dispatcher(name="dispatch_spline_filter1d")
 
+
 # ================== spline_filter1d ==================
 @dispatch_spline_filter1d.register(np.ndarray)
 def numpy_spline_filter1d(*args, **kwargs):
@@ -69,6 +72,7 @@ def register_cupy_spline_filter1d():
 
 
 dispatch_asarray = Dispatcher(name="dispatch_asarray")
+
 
 # ===================== asarray ========================
 @dispatch_asarray.register(np.ndarray)

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-import collections
+import collections.abc
 import inspect
 import numbers
 import re
@@ -61,13 +61,13 @@ def _get_depth_boundary(ndim, depth, boundary=None):
 
     if isinstance(depth, numbers.Number):
         depth = ndim * (depth,)
-    if not isinstance(depth, collections.Sized):
+    if not isinstance(depth, collections.abc.Sized):
         raise TypeError("Unexpected type for `depth`.")
     if len(depth) != ndim:
         raise ValueError("Expected `depth` to have a length equal to `ndim`.")
-    if isinstance(depth, collections.Sequence):
+    if isinstance(depth, collections.abc.Sequence):
         depth = dict(zip(range(ndim), depth))
-    if not isinstance(depth, collections.Mapping):
+    if not isinstance(depth, collections.abc.Mapping):
         raise TypeError("Unexpected type for `depth`.")
 
     if not all(map(lambda d: isinstance(d, numbers.Integral), depth.values())):
@@ -79,15 +79,15 @@ def _get_depth_boundary(ndim, depth, boundary=None):
 
     if (boundary is None) or isinstance(boundary, strlike):
         boundary = ndim * (boundary,)
-    if not isinstance(boundary, collections.Sized):
+    if not isinstance(boundary, collections.abc.Sized):
         raise TypeError("Unexpected type for `boundary`.")
     if len(boundary) != ndim:
         raise ValueError(
             "Expected `boundary` to have a length equal to `ndim`."
         )
-    if isinstance(boundary, collections.Sequence):
+    if isinstance(boundary, collections.abc.Sequence):
         boundary = dict(zip(range(ndim), boundary))
-    if not isinstance(boundary, collections.Mapping):
+    if not isinstance(boundary, collections.abc.Mapping):
         raise TypeError("Unexpected type for `boundary`.")
 
     type_check = lambda b: (b is None) or isinstance(b, strlike)  # noqa: E731

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -115,8 +115,8 @@ def affine_transform(
         raise NotImplementedError(f"Mode {mode} is not currently supported.")
 
     # process kwargs
-    # prefilter is not yet supported
     if prefilter and order > 1:
+        # prefilter is not yet supported for all modes
         if mode in ['nearest', 'grid-constant']:
             raise NotImplementedError(
                 f"order > 1 with mode='{mode}' is not supported."

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -113,6 +113,8 @@ def affine_transform(
     # prefilter is not yet supported
     if 'prefilter' in kwargs:
         if kwargs['prefilter'] and order > 1:
+
+
             warnings.warn('Currently, `dask_image.ndinterp.affine_transform` '
                           'doesn\'t support `prefilter=True`. Proceeding with'
                           ' `prefilter=False`, which if order > 1 can lead '
@@ -248,6 +250,10 @@ def spline_filter(
         depth=12,
         **kwargs
 ):
+
+    if not type(image) == da.core.Array:
+        image = da.from_array(image)
+
     # use dispatching mechanism to determine backend
     spline_filter_method = dispatch_spline_filter(image)
 
@@ -259,9 +265,8 @@ def spline_filter(
             "Passing array to output is not currently supported."
         )
 
-    # Note:
-    #     depths of 12 and 24 give results matching SciPy to approximately
-    #     single and double precision accuracy, respectively.
+    # Note: depths of 12 and 24 give results matching SciPy to approximately
+    #       single and double precision accuracy, respectively.
     depth, boundary = _get_depth_boundary(image.ndim, depth, "none")
 
     # cannot pass a func kwarg named "output" to map_overlap
@@ -292,6 +297,10 @@ def spline_filter1d(
         depth=12,
         **kwargs
 ):
+
+    if not type(image) == da.core.Array:
+        image = da.from_array(image)
+
     # use dispatching mechanism to determine backend
     spline_filter1d_method = dispatch_spline_filter1d(image)
 
@@ -303,7 +312,7 @@ def spline_filter1d(
             "Passing array to output is not currently supported."
         )
 
-    # use depth 0 on all except the filtered axis
+    # use depth 0 on all axes except the filtered axis
     if not np.isscalar(depth):
         raise ValueError("depth must be a scalar value")
     depths = [0,] * image.ndim

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -274,8 +274,8 @@ def spline_filter(
 
     try:
         dtype = np.dtype(output)
-    except TypeError:
-        raise TypeError(
+    except TypeError:     # pragma: no cover
+        raise TypeError(  # pragma: no cover
             "Could not coerce the provided output to a dtype. "
             "Passing array to output is not currently supported."
         )
@@ -332,8 +332,8 @@ def spline_filter1d(
 
     try:
         dtype = np.dtype(output)
-    except TypeError:
-        raise TypeError(
+    except TypeError:     # pragma: no cover
+        raise TypeError(  # pragma: no cover
             "Could not coerce the provided output to a dtype. "
             "Passing array to output is not currently supported."
         )
@@ -347,7 +347,7 @@ def spline_filter1d(
     depths = [0] * image.ndim
     depths[axis] = depth
 
-    if mode in ['wrap', 'grid-wrap']:
+    if mode in ['wrap']:
         raise NotImplementedError(f"mode={mode} is unsupported.")
 
     # cannot pass a func kwarg named "output" to map_overlap

--- a/docs/coverage.rst
+++ b/docs/coverage.rst
@@ -1,13 +1,13 @@
 *****************
-Function Coverage 
+Function Coverage
 *****************
 
 Coverage of dask-image vs scipy ndimage functions
 *************************************************
 
-This table shows which SciPy ndimage functions are supported by dask-image. 
+This table shows which SciPy ndimage functions are supported by dask-image.
 
-.. list-table:: 
+.. list-table::
    :widths: 25 25 50
    :header-rows: 0
 
@@ -205,10 +205,10 @@ This table shows which SciPy ndimage functions are supported by dask-image.
      - ✓
    * - ``spline_filter``
      - ✓
-     -
+     - ✓
    * - ``spline_filter1d``
      - ✓
-     -
+     - ✓
    * - ``standard_deviation``
      - ✓
      - ✓
@@ -233,4 +233,4 @@ This table shows which SciPy ndimage functions are supported by dask-image.
    * - ``zoom``
      - ✓
      -
-           
+

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -52,8 +52,9 @@ def validate_affine_transform(n=2,
         to `prefilter=False`.
     """
 
-#    if (interp_mode == 'nearest' and not have_scipy16):
-#        pytest.skip("requires SciPy >= 1.6.0")
+    if (interp_order > 1 and interp_mode == 'nearest' and not have_scipy16):
+        # not clear on the underlying cause, but this fails on older SciPy
+        pytest.skip("requires SciPy >= 1.6.0")
 
     # define test image
     a = input_output_shape_per_dim[0]

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -8,7 +8,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import scipy
-from scipy import ndimage
+import scipy.ndimage
 
 import dask_image.ndinterp as da_ndinterp
 
@@ -42,7 +42,7 @@ def validate_affine_transform(n=2,
                               prefilter=False
                               ):
     """
-    Compare the outputs of `ndimage.affine_transformation`
+    Compare the outputs of `scipy.ndimage.affine_transformation`
     and `dask_image.ndinterp.affine_transformation`.
 
     Notes
@@ -93,7 +93,7 @@ def validate_affine_transform(n=2,
     output_chunks = [input_output_chunksize_per_dim[1]] * n
 
     # transform with scipy
-    image_t_scipy = ndimage.affine_transform(
+    image_t_scipy = scipy.ndimage.affine_transform(
         image, matrix, offset,
         output_shape=output_shape,
         order=interp_order,

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -24,9 +24,6 @@ if np.lib.NumpyVersion(scipy.__version__) >= '1.6.0':
     _unsupported_periodic_modes += ['grid-constant', 'grid-mirror',
                                     'grid-wrap']
 
-print(f'np.lib.NumpyVersion(scipy.__version__)={np.lib.NumpyVersion(scipy.__version__)}')
-print(f'_supported_modes={_supported_modes}')
-
 
 def validate_affine_transform(n=2,
                               matrix=None,

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -68,7 +68,8 @@ def validate_affine_transform(n=2,
         import cupy as cp
         image_da = image_da.map_blocks(cp.asarray)
 
-    if (prefilter
+    if (
+        prefilter
         and interp_mode in _supported_prefilter_modes
         and interp_order > 1
         and version.parse(dask.__version__) < version.parse("2020.1.0")
@@ -154,7 +155,7 @@ def test_affine_transform_cupy(n,
                                interp_order,
                                input_output_chunksize_per_dim,
                                random_seed):
-    cupy = pytest.importorskip("cupy", minversion="6.0.0")
+    pytest.importorskip("cupy", minversion="6.0.0")
 
     kwargs = dict()
     kwargs['n'] = n

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -188,6 +188,7 @@ def test_affine_transform_prefilter_modes(n, interp_order, interp_mode):
 
     validate_affine_transform(
         n=n,
+        input_output_shape_per_dim=(32, 32),
         interp_order=interp_order,
         interp_mode=interp_mode,
         prefilter=True,

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -72,7 +72,8 @@ def validate_spline_filter(n=2,
     image_t_dask_computed = image_t_dask.compute()
 
     rtol = atol = 1e-6
-    assert image_t_scipy.dtype == image_t_dask_computed.dtype
+    out_dtype = np.dtype(output)
+    assert image_t_scipy.dtype == image_t_dask_computed.dtype == out_dtype
     assert np.allclose(image_t_scipy, image_t_dask_computed,
                        rtol=rtol, atol=atol)
 
@@ -173,3 +174,20 @@ def test_spline_filter_unsupported_modes(
             interp_mode=interp_mode,
             axis=axis,
         )
+
+
+@pytest.mark.parametrize(
+    "output", [np.float64, np.float32, "float32", np.dtype(np.float32)]
+)
+@pytest.mark.parametrize("axis", [None, -1])
+def test_spline_filter_output_dtype(
+    output,
+    axis,
+):
+
+    validate_spline_filter(
+        axis_size=32,
+        interp_order=3,
+        output=output,
+        axis=axis,
+    )

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -38,7 +38,8 @@ def validate_spline_filter(n=2,
     `spline_transform1d` is tested instead.
 
     """
-    if (np.dtype(output) != np.float64
+    if (
+        np.dtype(output) != np.float64
         and version.parse(scipy.__version__) < version.parse('1.4.0')
     ):
         pytest.skip("bug in output dtype handling in SciPy < 1.4")
@@ -142,7 +143,7 @@ def test_spline_filter_cupy(
     input_as_non_dask_array,
 ):
 
-    cupy = pytest.importorskip("cupy", minversion="6.0.0")
+    pytest.importorskip("cupy", minversion="6.0.0")
 
     validate_spline_filter(
         n=n,
@@ -185,8 +186,6 @@ def test_spline_filter1d_general(
 
 @pytest.mark.parametrize("axis", [None, -1])
 def test_spline_filter_non_dask_array_input(axis):
-    if axis == 1 and n < 2:
-        pytest.skip(msg="skip axis=1 for 1d signals")
 
     validate_spline_filter(
         axis=axis,
@@ -197,8 +196,6 @@ def test_spline_filter_non_dask_array_input(axis):
 @pytest.mark.parametrize("depth", [None, 24])
 @pytest.mark.parametrize("axis", [None, -1])
 def test_spline_filter_non_default_depth(depth, axis):
-    if axis == 1 and n < 2:
-        pytest.skip(msg="skip axis=1 for 1d signals")
 
     validate_spline_filter(
         axis=axis,

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import dask.array as da
+import numpy as np
+import pytest
+import scipy
+from scipy import ndimage
+
+import dask_image.ndinterp as da_ndinterp
+
+# mode lists for the case with prefilter = False
+_supported_modes = ['constant', 'nearest', 'reflect', 'mirror']
+_unsupported_modes = ['wrap']
+
+# additional modes are present in SciPy >= 1.6.0
+if np.lib.NumpyVersion(scipy.__version__) >= '1.6.0':
+    _supported_modes += ['grid-constant', 'grid-mirror']
+    _unsupported_modes += ['grid-wrap']
+
+
+def validate_spline_filter(n=2,
+                           axis_size=64,
+                           interp_order=1,
+                           interp_mode='constant',
+                           chunksize=32,
+                           output=np.float64,
+                           random_seed=0,
+                           use_cupy=False,
+                           axis=None):
+    """
+    Compare the outputs of `ndimage.spline_transform`
+    and `dask_image.ndinterp.spline_transform`. If axis is not None, then
+    `spline_transform1d` is tested instead.
+
+    """
+
+    # define test image
+    np.random.seed(random_seed)
+    image = np.random.random([axis_size] * n)
+
+    # transform into dask array
+    image_da = da.from_array(image, chunks=[chunksize] * n)
+    if use_cupy:
+        import cupy as cp
+        image_da = image_da.map_blocks(cp.asarray)
+
+    if axis is not None:
+        scipy_func = ndimage.spline_filter1d
+        dask_image_func = da_ndinterp.spline_filter1d
+        kwargs = {'axis': axis}
+    else:
+        scipy_func = ndimage.spline_filter
+        dask_image_func = da_ndinterp.spline_filter
+        kwargs = {}
+
+    # transform with scipy
+    image_t_scipy = scipy_func(
+        image,
+        output=output,
+        order=interp_order,
+        mode=interp_mode,
+        **kwargs)
+
+    # transform with dask-image
+    image_t_dask = dask_image_func(
+        image_da,
+        output=output,
+        order=interp_order,
+        mode=interp_mode,
+        **kwargs)
+    image_t_dask_computed = image_t_dask.compute()
+
+    rtol = atol = 1e-6
+    assert image_t_scipy.dtype == image_t_dask_computed.dtype
+    assert np.allclose(image_t_scipy, image_t_dask_computed,
+                       rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+@pytest.mark.parametrize("axis_size", [64])
+@pytest.mark.parametrize("interp_order", range(2, 6))
+@pytest.mark.parametrize("interp_mode", _supported_modes)
+@pytest.mark.parametrize("chunksize", [32, 15])
+def test_spline_filter_general(
+    n,
+    axis_size,
+    interp_order,
+    interp_mode,
+    chunksize,
+):
+
+    validate_spline_filter(
+        n=n,
+        axis_size=axis_size,
+        interp_order=interp_order,
+        interp_mode=interp_mode,
+        chunksize=chunksize,
+        axis=None,
+    )
+
+
+@pytest.mark.cupy
+@pytest.mark.parametrize("n", [2])
+@pytest.mark.parametrize("axis_size", [32])
+@pytest.mark.parametrize("interp_order", range(2, 6))
+@pytest.mark.parametrize("interp_mode", _supported_modes[::2])
+@pytest.mark.parametrize("chunksize", [16])
+@pytest.mark.parametrize("axis", [None, -1])
+def test_spline_filter_cupy(
+    n,
+    axis_size,
+    interp_order,
+    interp_mode,
+    chunksize,
+    axis,
+):
+
+    cupy = pytest.importorskip("cupy", minversion="6.0.0")
+
+    validate_spline_filter(
+        n=n,
+        axis_size=axis_size,
+        interp_order=interp_order,
+        interp_mode=interp_mode,
+        chunksize=chunksize,
+        axis=axis,
+        use_cupy=True,
+    )
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+@pytest.mark.parametrize("axis_size", [48, 27])
+@pytest.mark.parametrize("interp_order", range(2, 6))
+@pytest.mark.parametrize("interp_mode", _supported_modes)
+@pytest.mark.parametrize("chunksize", [33])
+@pytest.mark.parametrize("axis", [0, 1, -1])
+def test_spline_filter1d_general(
+    n,
+    axis_size,
+    interp_order,
+    interp_mode,
+    chunksize,
+    axis,
+):
+    if axis == 1 and n < 2:
+        pytest.skip(msg="skip axis=1 for 1d signals")
+
+    validate_spline_filter(
+        n=n,
+        axis_size=axis_size,
+        interp_order=interp_order,
+        interp_mode=interp_mode,
+        chunksize=chunksize,
+        axis=axis,
+    )
+
+@pytest.mark.parametrize("axis_size", [32])
+@pytest.mark.parametrize("interp_order", range(2, 6))
+@pytest.mark.parametrize("interp_mode", _unsupported_modes)
+@pytest.mark.parametrize("axis", [None, -1])
+def test_spline_filter_unsupported_modes(
+    axis_size,
+    interp_order,
+    interp_mode,
+    axis,
+):
+
+    with pytest.raises(NotImplementedError):
+        validate_spline_filter(
+            axis_size=axis_size,
+            interp_order=interp_order,
+            interp_mode=interp_mode,
+            axis=axis,
+        )

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -18,8 +18,7 @@ _unsupported_modes = ['wrap']
 
 # additional modes are present in SciPy >= 1.6.0
 if version.parse(scipy.__version__) >= version.parse('1.6.0'):
-    _supported_modes += ['grid-constant', 'grid-mirror']
-    _unsupported_modes += ['grid-wrap']
+    _supported_modes += ['grid-constant', 'grid-mirror', 'grid-wrap']
 
 
 def validate_spline_filter(n=2,

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -255,7 +255,7 @@ def test_spline_filter_array_output_unsupported(axis):
 
     n = 2
     axis_size = 32
-    shape = (n,) * axis_size
+    shape = (axis_size,) * n
 
     with pytest.raises(TypeError):
         validate_spline_filter(

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -8,7 +8,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import scipy
-from scipy import ndimage
+import scipy.ndimage
 
 import dask_image.ndinterp as da_ndinterp
 
@@ -33,7 +33,7 @@ def validate_spline_filter(n=2,
                            input_as_non_dask_array=False,
                            depth=None):
     """
-    Compare the outputs of `ndimage.spline_transform`
+    Compare the outputs of `scipy.ndimage.spline_transform`
     and `dask_image.ndinterp.spline_transform`. If axis is not None, then
     `spline_transform1d` is tested instead.
 
@@ -69,11 +69,11 @@ def validate_spline_filter(n=2,
             image_da = image_da.map_blocks(cp.asarray)
 
     if axis is not None:
-        scipy_func = ndimage.spline_filter1d
+        scipy_func = scipy.ndimage.spline_filter1d
         dask_image_func = da_ndinterp.spline_filter1d
         kwargs = {'axis': axis}
     else:
-        scipy_func = ndimage.spline_filter
+        scipy_func = scipy.ndimage.spline_filter
         dask_image_func = da_ndinterp.spline_filter
         kwargs = {}
 

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -49,9 +49,9 @@ def validate_spline_filter(n=2,
 
     if version.parse(dask.__version__) < version.parse("2020.1.0"):
         # older dask will fail if any chunks have size smaller than depth
-        depth = da_ndinterp._get_default_depth(interp_order)
+        _depth = da_ndinterp._get_default_depth(interp_order)
         rem = axis_size % chunksize
-        if chunksize < depth or (rem != 0 and rem < depth):
+        if chunksize < _depth or (rem != 0 and rem < _depth):
             pytest.skip("older dask doesn't automatically rechunk")
 
     if input_as_non_dask_array:


### PR DESCRIPTION
This PR adds the spline prefiltering functions that are correspond to:
`scipy.ndimage.spline_filter`
`scipy.ndimage.spline_filter1d`

The periodic modes `"wrap"` and `"grid-wrap"` are not currently supported, but all other modes are.

The one empirical nature of this implementation is the equation I came up with for estimating the overlap (depth) needed based on the interpolation order. In practice these are infinite impulse response (IIR) filters, but in practice the error terms decay pretty quickly with distance from an edge and the rate of decay is related to the magnitude of the filter poles. The current settings are enough for tests to pass at the tolerance of 1e-6 used in the tests. With the current default, the `depth` currently ends up being 11, 14, 19 and 22 for spline `order` of 2, 3, 4 and 5, respectively. I exposed a `depth` keyword-only argument in case users want to override this setting, but am not certain if that is desirable. 

This PR also enables use of `prefilter=True` in the existing `affine_transform` function when `mode='constant'`. This is needed to get good results with order > 1. Although `reflect` and `mirror` are also supported by the `spline_filter` functions added here, they are not currently supported in `affine_transform` itself. I have not yet tried to support `mode='nearest'` or `mode='grid-constant'` for use within `affine_transform` because those two cases do not have an analytic solution implemented and involve the need for temporary internal padding in SciPy's own implementation, making it more difficult to adapt here.
