### PR TITLE
affine_transform: increased shape of required input array slices

### DIFF
--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -184,7 +184,7 @@ def affine_transform(
             rel_image_f[dim] = np.clip(rel_image_f[dim], 0, s - 1)
 
         rel_image_slice = tuple([slice(int(rel_image_i[dim]),
-                                       int(rel_image_f[dim]) + 1)
+                                       int(rel_image_f[dim]) + 2)
                                  for dim in range(n)])
 
         rel_image = image[rel_image_slice]

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -45,7 +45,8 @@ def validate_affine_transform(n=2,
 
     # define (random) transformation
     if matrix is None:
-        matrix = np.eye(n) + (np.random.random((n, n)) - 0.5) / 5.
+        # make sure to substantially deviate from unity matrix
+        matrix = np.eye(n) + (np.random.random((n, n)) - 0.5) * 5.
     if offset is None:
         offset = (np.random.random(n) - 0.5) / 5. * np.array(image.shape)
 


### PR DESCRIPTION
This PR fixes a problem revealed by the tests of @martinschorb when using `affine_transform` within `rotate` in this PR https://github.com/dask/dask-image/pull/213.

Some choices of transformation parameters, which hadn't been covered in the tests so far, require a larger input array slice to compute the output chunks.

Only code change in this PR: `+2` instead of `+1`:

```python
        rel_image_slice = tuple([slice(int(rel_image_i[dim]),
                                       int(rel_image_f[dim]) + 2)
                                 for dim in range(n)])
```

I modified the tests to reflect the requirement for these larger input slices.
