### PR TITLE
ENH: add remaining kwargs to binary_closing and binary_opening

### DIFF
--- a/dask_image/ndmorph/__init__.py
+++ b/dask_image/ndmorph/__init__.py
@@ -24,20 +24,28 @@ __all__ = [
 def binary_closing(image,
                    structure=None,
                    iterations=1,
-                   origin=0):
+                   origin=0,
+                   mask=None,
+                   border_value=0,
+                   brute_force=False):
     image = (image != 0)
 
     structure = _utils._get_structure(image, structure)
     iterations = _utils._get_iterations(iterations)
     origin = _utils._get_origin(structure.shape, origin)
 
+    kwargs =  dict(
+        structure=structure,
+        iterations=iterations,
+        origin=origin,
+        mask=mask,
+        border_value=border_value,
+        brute_force=brute_force
+    )
+
     result = image
-    result = binary_dilation(
-        result, structure=structure, iterations=iterations, origin=origin
-    )
-    result = binary_erosion(
-        result, structure=structure, iterations=iterations, origin=origin
-    )
+    result = binary_dilation(result, **kwargs)
+    result = binary_erosion(result, **kwargs)
 
     return result
 
@@ -94,19 +102,27 @@ def binary_erosion(image,
 def binary_opening(image,
                    structure=None,
                    iterations=1,
-                   origin=0):
+                   origin=0,
+                   mask=None,
+                   border_value=0,
+                   brute_force=False):
     image = (image != 0)
 
     structure = _utils._get_structure(image, structure)
     iterations = _utils._get_iterations(iterations)
     origin = _utils._get_origin(structure.shape, origin)
 
+    kwargs =  dict(
+        structure=structure,
+        iterations=iterations,
+        origin=origin,
+        mask=mask,
+        border_value=border_value,
+        brute_force=brute_force
+    )
+
     result = image
-    result = binary_erosion(
-        result, structure=structure, iterations=iterations, origin=origin
-    )
-    result = binary_dilation(
-        result, structure=structure, iterations=iterations, origin=origin
-    )
+    result = binary_erosion(result, **kwargs)
+    result = binary_dilation(result, **kwargs)
 
     return result

--- a/tests/test_dask_image/test_ndmorph/test_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_ndmorph.py
@@ -108,8 +108,10 @@ def test_errs_binary_ops_iter(funcname,
 @pytest.mark.parametrize(
     "funcname",
     [
+        "binary_closing",
         "binary_dilation",
         "binary_erosion",
+        "binary_opening",
     ]
 )
 @pytest.mark.parametrize(
@@ -371,8 +373,10 @@ def test_binary_ops_iter(funcname,
 @pytest.mark.parametrize(
     "funcname",
     [
+        "binary_closing",
         "binary_dilation",
         "binary_erosion",
+        "binary_opening",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR just adds all currently missing keyword arguments from the SciPy API for `binary_opening` and `binary_closing`. Fortunately, these same arguments were already present (and tested) for the underlying erosion and dilation functions, so this ended up being easy!
