### PR TITLE
ndfourier: support n > 0 (for rfft) and improve performance

### DIFF
--- a/dask_image/ndfourier/__init__.py
+++ b/dask_image/ndfourier/__init__.py
@@ -69,6 +69,8 @@ def fourier_gaussian(image, sigma, n=-1, axis=-1):
     ang_freq_grid = _utils._get_ang_freq_grid(
         image.shape,
         chunks=image.chunks,
+        n=n,
+        axis=axis,
         dtype=sigma.dtype
     )
 
@@ -139,6 +141,8 @@ def fourier_shift(image, shift, n=-1, axis=-1):
     ang_freq_grid = _utils._get_ang_freq_grid(
         image.shape,
         chunks=image.chunks,
+        n=n,
+        axis=axis,
         dtype=shift.dtype
     )
 
@@ -204,6 +208,8 @@ def fourier_uniform(image, size, n=-1, axis=-1):
     freq_grid = _utils._get_freq_grid(
         image.shape,
         chunks=image.chunks,
+        n=n,
+        axis=axis,
         dtype=size.dtype
     )
 

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -8,7 +8,7 @@ import numpy
 import dask.array
 
 
-def _get_freq_grid(shape, chunks, dtype=float):
+def _get_freq_grid(shape, chunks, axis, n, dtype=float):
     assert len(shape) == len(chunks)
 
     shape = tuple(shape)
@@ -17,17 +17,23 @@ def _get_freq_grid(shape, chunks, dtype=float):
     assert (issubclass(dtype, numbers.Real) and
             not issubclass(dtype, numbers.Integral))
 
-    freq_grid = [
-        dask.array.fft.fftfreq(s, chunks=c).astype(dtype)
-        for s, c in zip(shape, chunks)
-    ]
+    axis = axis % len(shape)
+
+    freq_grid = []
+    for ax, (s, c) in enumerate(zip(shape, chunks)):
+        if axis == ax and n > 0:
+            f = dask.array.fft.rfftfreq(n, chunks=c).astype(dtype)
+        else:
+            f = dask.array.fft.fftfreq(s, chunks=c).astype(dtype)
+        freq_grid.append(f)
+
     freq_grid = dask.array.meshgrid(*freq_grid, indexing="ij")
     freq_grid = dask.array.stack(freq_grid)
 
     return freq_grid
 
 
-def _get_ang_freq_grid(shape, chunks, dtype=float):
+def _get_ang_freq_grid(shape, chunks, axis, n, dtype=float):
     dtype = numpy.dtype(dtype).type
 
     assert (issubclass(dtype, numbers.Real) and
@@ -35,7 +41,7 @@ def _get_ang_freq_grid(shape, chunks, dtype=float):
 
     pi = dtype(numpy.pi)
 
-    freq_grid = _get_freq_grid(shape, chunks, dtype=dtype)
+    freq_grid = _get_freq_grid(shape, chunks, axis, n, dtype=dtype)
     ang_freq_grid = (2 * pi) * freq_grid
 
     return ang_freq_grid
@@ -59,9 +65,10 @@ def _norm_args(a, s, n=-1, axis=-1):
             "Shape of `s` must be 1-D and equal to the input's rank."
         )
 
-    if n != -1:
+    if n != -1 and a.shape[axis] != (n // 2 + 1):
         raise NotImplementedError(
-            "Currently `n` other than -1 is unsupported."
+            "In the case of real-valued images, it is required that "
+            "(n // 2 + 1) == image.shape[axis]."
         )
 
     return (a, s, n, axis)

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -218,15 +218,28 @@ def test_fourier_filter_non_positive(funcname, s):
         "fourier_uniform",
     ]
 )
-def test_fourier_filter(funcname, s):
+@pytest.mark.parametrize(
+    "n, axis",
+    [
+        ('real', -1),
+        ('real', 0),
+        (-1, -1),
+    ]
+)
+def test_fourier_filter(funcname, s, n, axis):
     da_func = getattr(da_ndf, funcname)
     sp_func = getattr(sp_ndf, funcname)
 
-    a = np.arange(140.0).reshape(10, 14).astype(complex)
+    shape = (10, 14)
+    if n == 'real':
+        n = 2 * shape[axis] - 1
+    dtype = np.float64 if n != -1 else np.complex128
+
+    a = np.arange(140.0).reshape(shape).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    r_a = sp_func(a, s)
-    r_d = da_func(d, s)
+    r_a = sp_func(a, s, n=n, axis=axis)
+    r_d = da_func(d, s, n=n, axis=axis)
 
     assert d.chunks == r_d.chunks
 

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -219,21 +219,20 @@ def test_fourier_filter_non_positive(funcname, s):
     ]
 )
 @pytest.mark.parametrize(
-    "n, axis",
+    "real_fft, axis",
     [
-        ('real', -1),
-        ('real', 0),
-        (-1, -1),
+        (True, -1),
+        (True, 0),
+        (False, -1),
     ]
 )
-def test_fourier_filter(funcname, s, n, axis):
+def test_fourier_filter(funcname, s, real_fft, axis):
     da_func = getattr(da_ndf, funcname)
     sp_func = getattr(sp_ndf, funcname)
 
     shape = (10, 14)
-    if n == 'real':
-        n = 2 * shape[axis] - 1
-    dtype = np.float64 if n != -1 else np.complex128
+    n = 2 * shape[axis] - 1 if real_fft else -1
+    dtype = np.float64 if real_fft else np.complex128
 
     a = np.arange(140.0).reshape(shape).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))


### PR DESCRIPTION
The first commit here support n > 0, which is intended for use when the image to be filtered was created via a real-to-complex FFT. It is mainly just needing to use `dask.array.fft.rfftfreq` instead of `dask.array.fft.fftfreq` on the corresponding axis.

The second commit here refactors the separable filtering to avoid dense frequency arrays of shape `(image.ndim,) + image.shape`. This is done using meshgrid's `sparse=True` option to get a series of separable 1D frequency arrays instead. These can then be applied separably along each axis of the `image`, avoiding the need for `tensordot`. This should reduce computation time and peak memory usage.

I did some local benchmarking and typically saw factor 1.5-3.5 improvement in various cases. This makes sense, as rather than computing, for example, the Gaussian via `dask.array.exp` on the dense frequency grid, we just have to compute it on much smaller 1D arrays instead.
