### PR TITLE
BUG: add missing import of warnings in dask_image.ndmeasure

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -7,6 +7,7 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 import collections
 import functools
 import operator
+import warnings
 
 import numpy
 


### PR DESCRIPTION
This PR just adds a missing import of the `warnings` module.

If the user tries to call `dask_image.ndmeasure.sum`, it currently results in a `NameError` being raised rather than the desired warning to use `sum_labels` instead. 