### PR TITLE
Code style cleanup

### DIFF
--- a/.gen_ci_support/ff_ci_pr_build.py
+++ b/.gen_ci_support/ff_ci_pr_build.py
@@ -13,15 +13,6 @@ it is the most recent build number or if it is not a PR (e.g. a build on a
 normal branch), then the build proceeds without issues.
 """
 
-
-try:
-    from future_builtins import (
-        map,
-        filter,
-    )
-except ImportError:
-    pass
-
 import argparse
 import codecs
 import contextlib

--- a/dask_image/__init__.py
+++ b/dask_image/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions

--- a/dask_image/dispatch/_dispatch_ndfilters.py
+++ b/dask_image/dispatch/_dispatch_ndfilters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ._dispatcher import Dispatcher
 

--- a/dask_image/dispatch/_dispatch_ndinterp.py
+++ b/dask_image/dispatch/_dispatch_ndinterp.py
@@ -10,8 +10,8 @@ __all__ = [
     "dispatch_asarray",
 ]
 
-
 dispatch_affine_transform = Dispatcher(name="dispatch_affine_transform")
+
 
 # ================== affine_transform ==================
 @dispatch_affine_transform.register(np.ndarray)
@@ -31,6 +31,7 @@ def register_cupy_affine_transform():
 
 
 dispatch_asarray = Dispatcher(name="dispatch_asarray")
+
 
 # ===================== asarray ========================
 @dispatch_asarray.register(np.ndarray)

--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -4,7 +4,6 @@ import numbers
 import warnings
 
 import dask.array as da
-import dask.delayed
 import numpy as np
 import pims
 

--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -3,8 +3,7 @@ import glob
 import numbers
 import warnings
 
-import dask
-import dask.array
+import dask.array as da
 import dask.delayed
 import numpy as np
 import pims
@@ -69,16 +68,16 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
     # place source filenames into dask array
     filenames = sorted(glob.glob(sfname))  # pims also does this
     if len(filenames) > 1:
-        ar = dask.array.from_array(filenames, chunks=(nframes,))
+        ar = da.from_array(filenames, chunks=(nframes,))
         multiple_files = True
     else:
-        ar = dask.array.from_array(filenames * shape[0], chunks=(nframes,))
+        ar = da.from_array(filenames * shape[0], chunks=(nframes,))
         multiple_files = False
 
     # read in data using encoded filenames
     a = ar.map_blocks(
         _map_read_frame,
-        chunks=dask.array.core.normalize_chunks(
+        chunks=da.core.normalize_chunks(
             (nframes,) + shape[1:], shape),
         multiple_files=multiple_files,
         new_axis=list(range(1, len(shape))),

--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -6,7 +6,7 @@ import warnings
 import dask
 import dask.array
 import dask.delayed
-import numpy
+import numpy as np
 import pims
 
 from . import _utils
@@ -41,14 +41,14 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
         raise ValueError("`nframes` must be greater than zero.")
 
     if arraytype == "numpy":
-        arrayfunc = numpy.asanyarray
+        arrayfunc = np.asanyarray
     elif arraytype == "cupy":   # pragma: no cover
         import cupy
         arrayfunc = cupy.asanyarray
 
     with pims.open(sfname) as imgs:
         shape = (len(imgs),) + imgs.frame_shape
-        dtype = numpy.dtype(imgs.pixel_type)
+        dtype = np.dtype(imgs.pixel_type)
 
     if nframes == -1:
         nframes = shape[0]

--- a/dask_image/imread/_utils.py
+++ b/dask_image/imread/_utils.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import numpy
+import numpy as np
 import pims
 
 
-def _read_frame(fn, i, *, arrayfunc=numpy.asanyarray):
+def _read_frame(fn, i, *, arrayfunc=np.asanyarray):
     with pims.open(fn) as imgs:
         return arrayfunc(imgs[i])

--- a/dask_image/ndfilters/__init__.py
+++ b/dask_image/ndfilters/__init__.py
@@ -19,46 +19,16 @@ __all__ = [
     "threshold_local",
 ]
 
-from ._conv import (
-    convolve,
-    correlate,
-)
-
-from ._diff import (
-    laplace,
-)
-
-from ._edge import (
-    prewitt,
-    sobel,
-)
-
-from ._gaussian import (
-    gaussian_filter,
-    gaussian_gradient_magnitude,
-    gaussian_laplace,
-)
-
-from ._generic import (
-    generic_filter,
-)
-
-from ._order import (
-    minimum_filter,
-    median_filter,
-    maximum_filter,
-    rank_filter,
-    percentile_filter,
-)
-
-from ._smooth import (
-    uniform_filter,
-)
-
-from ._threshold import (
-    threshold_local,
-)
-
+from ._conv import convolve, correlate
+from ._diff import laplace
+from ._edge import prewitt, sobel
+from ._gaussian import (gaussian_filter, gaussian_gradient_magnitude,
+                        gaussian_laplace)
+from ._generic import generic_filter
+from ._order import (maximum_filter, median_filter, minimum_filter,
+                     percentile_filter, rank_filter)
+from ._smooth import uniform_filter
+from ._threshold import threshold_local
 
 convolve.__module__ = __name__
 correlate.__module__ = __name__

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import (dispatch_convolve,
                                             dispatch_correlate)

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import scipy.ndimage.filters
 
-from . import _utils
+from ..dispatch._dispatch_ndfilters import (dispatch_convolve,
+                                            dispatch_correlate)
 from ..dispatch._utils import check_arraytypes_compatible
-from ..dispatch._dispatch_ndfilters import (
-    dispatch_convolve,
-    dispatch_correlate)
+from . import _utils
 
 __all__ = [
     "convolve",

--- a/dask_image/ndfilters/_diff.py
+++ b/dask_image/ndfilters/_diff.py
@@ -3,8 +3,8 @@
 
 import scipy.ndimage.filters
 
-from . import _utils
 from ..dispatch._dispatch_ndfilters import dispatch_laplace
+from . import _utils
 
 __all__ = [
     "laplace",

--- a/dask_image/ndfilters/_diff.py
+++ b/dask_image/ndfilters/_diff.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import dispatch_laplace
 from . import _utils

--- a/dask_image/ndfilters/_edge.py
+++ b/dask_image/ndfilters/_edge.py
@@ -5,8 +5,8 @@ import numbers
 
 import scipy.ndimage.filters
 
-from . import _utils
 from ..dispatch._dispatch_ndfilters import dispatch_prewitt, dispatch_sobel
+from . import _utils
 
 __all__ = [
     "prewitt",

--- a/dask_image/ndfilters/_edge.py
+++ b/dask_image/ndfilters/_edge.py
@@ -3,7 +3,7 @@
 
 import numbers
 
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import dispatch_prewitt, dispatch_sobel
 from . import _utils

--- a/dask_image/ndfilters/_gaussian.py
+++ b/dask_image/ndfilters/_gaussian.py
@@ -3,7 +3,7 @@
 
 import numbers
 
-import numpy
+import numpy as np
 import scipy.ndimage.filters
 
 from ..dispatch._dispatch_ndfilters import (
@@ -22,9 +22,9 @@ __all__ = [
 def _get_sigmas(image, sigma):
     ndim = image.ndim
 
-    nsigmas = numpy.array(sigma)
+    nsigmas = np.array(sigma)
     if nsigmas.ndim == 0:
-        nsigmas = numpy.array(ndim * [nsigmas[()]])
+        nsigmas = np.array(ndim * [nsigmas[()]])
 
     if nsigmas.ndim != 1:
         raise RuntimeError(
@@ -45,12 +45,12 @@ def _get_sigmas(image, sigma):
 
 
 def _get_border(image, sigma, truncate):
-    sigma = numpy.array(_get_sigmas(image, sigma))
+    sigma = np.array(_get_sigmas(image, sigma))
 
     if not isinstance(truncate, numbers.Real):
         raise TypeError("Must have a real truncate value.")
 
-    half_shape = tuple(numpy.ceil(sigma * truncate).astype(int))
+    half_shape = tuple(np.ceil(sigma * truncate).astype(int))
 
     return half_shape
 

--- a/dask_image/ndfilters/_gaussian.py
+++ b/dask_image/ndfilters/_gaussian.py
@@ -4,7 +4,7 @@
 import numbers
 
 import numpy as np
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import (
     dispatch_gaussian_filter, dispatch_gaussian_gradient_magnitude,

--- a/dask_image/ndfilters/_gaussian.py
+++ b/dask_image/ndfilters/_gaussian.py
@@ -6,11 +6,10 @@ import numbers
 import numpy
 import scipy.ndimage.filters
 
-from . import _utils
 from ..dispatch._dispatch_ndfilters import (
-    dispatch_gaussian_filter,
-    dispatch_gaussian_gradient_magnitude,
+    dispatch_gaussian_filter, dispatch_gaussian_gradient_magnitude,
     dispatch_gaussian_laplace)
+from . import _utils
 
 __all__ = [
     "gaussian_filter",

--- a/dask_image/ndfilters/_generic.py
+++ b/dask_image/ndfilters/_generic.py
@@ -3,8 +3,8 @@
 import numpy as np
 import scipy.ndimage.filters
 
-from . import _utils
 from ..dispatch._dispatch_ndfilters import dispatch_generic_filter
+from . import _utils
 
 __all__ = [
     "generic_filter",

--- a/dask_image/ndfilters/_generic.py
+++ b/dask_image/ndfilters/_generic.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import dispatch_generic_filter
 from . import _utils

--- a/dask_image/ndfilters/_order.py
+++ b/dask_image/ndfilters/_order.py
@@ -2,13 +2,12 @@
 
 import scipy.ndimage.filters
 
+from ..dispatch._dispatch_ndfilters import (dispatch_maximum_filter,
+                                            dispatch_median_filter,
+                                            dispatch_minimum_filter,
+                                            dispatch_percentile_filter,
+                                            dispatch_rank_filter)
 from . import _utils
-from ..dispatch._dispatch_ndfilters import (
-    dispatch_minimum_filter,
-    dispatch_median_filter,
-    dispatch_maximum_filter,
-    dispatch_rank_filter,
-    dispatch_percentile_filter)
 
 __all__ = [
     "minimum_filter",

--- a/dask_image/ndfilters/_order.py
+++ b/dask_image/ndfilters/_order.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import (dispatch_maximum_filter,
                                             dispatch_median_filter,

--- a/dask_image/ndfilters/_smooth.py
+++ b/dask_image/ndfilters/_smooth.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-import scipy.ndimage.filters
+import scipy.ndimage
 
 from ..dispatch._dispatch_ndfilters import dispatch_uniform_filter
 from . import _utils

--- a/dask_image/ndfilters/_smooth.py
+++ b/dask_image/ndfilters/_smooth.py
@@ -3,9 +3,9 @@
 
 import scipy.ndimage.filters
 
+from ..dispatch._dispatch_ndfilters import dispatch_uniform_filter
 from . import _utils
 from ._gaussian import gaussian_filter
-from ..dispatch._dispatch_ndfilters import dispatch_uniform_filter
 
 __all__ = [
     "uniform_filter",

--- a/dask_image/ndfilters/_threshold.py
+++ b/dask_image/ndfilters/_threshold.py
@@ -1,8 +1,8 @@
 import dask.array as da
 import numpy as np
 
-from . import _gaussian, _generic, _order
 from ..dispatch._dispatch_ndfilters import dispatch_threshold_local_mean
+from . import _gaussian, _generic, _order
 
 __all__ = [
     "threshold_local",

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import division
-
 import collections
 import inspect
 import numbers

--- a/dask_image/ndfilters/_utils.py
+++ b/dask_image/ndfilters/_utils.py
@@ -4,7 +4,7 @@ import inspect
 import numbers
 import re
 
-import numpy
+import numpy as np
 
 
 def _get_docstring(func):
@@ -100,7 +100,7 @@ def _get_size(ndim, size):
 
     if isinstance(size, numbers.Number):
         size = ndim * (size,)
-    size = numpy.array(size)
+    size = np.array(size)
 
     if size.ndim != 1:
         raise RuntimeError("The size must have only one dimension.")
@@ -117,13 +117,13 @@ def _get_size(ndim, size):
 
 
 def _get_origin(size, origin=0):
-    size = numpy.array(size)
+    size = np.array(size)
     ndim = len(size)
 
     if isinstance(origin, numbers.Number):
         origin = ndim * (origin,)
 
-    origin = numpy.array(origin)
+    origin = np.array(origin)
 
     if not issubclass(origin.dtype.type, numbers.Integral):
         raise TypeError("The origin must be of integral type.")
@@ -147,8 +147,8 @@ def _get_origin(size, origin=0):
 
 
 def _get_depth(size, origin=0):
-    origin = numpy.array(_get_origin(size, origin))
-    size = numpy.array(size)
+    origin = np.array(_get_origin(size, origin))
+    size = np.array(size)
 
     half_size = size // 2
     depth = half_size + abs(origin)
@@ -168,7 +168,7 @@ def _get_footprint(ndim, size=None, footprint=None):
     # Get a footprint based on the size.
     if size is not None:
         size = _get_size(ndim, size)
-        footprint = numpy.ones(size, dtype=bool)
+        footprint = np.ones(size, dtype=bool)
 
     # Validate the footprint.
     if footprint.ndim != ndim:

--- a/dask_image/ndfourier/__init__.py
+++ b/dask_image/ndfourier/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import numbers
 
-import dask.array
+import dask.array as da
 
 from . import _utils
 
@@ -66,9 +66,7 @@ def fourier_gaussian(image, sigma, n=-1, axis=-1):
 
     # Compute Fourier transformed Gaussian
     scale = (sigma ** 2) / -2
-    gaussian = dask.array.exp(
-        dask.array.tensordot(scale, ang_freq_grid ** 2, axes=1)
-    )
+    gaussian = da.exp(da.tensordot(scale, ang_freq_grid ** 2, axes=1))
 
     result = image * gaussian
 
@@ -135,9 +133,7 @@ def fourier_shift(image, shift, n=-1, axis=-1):
     )
 
     # Apply shift
-    phase_shift = dask.array.exp(
-        (-J) * dask.array.tensordot(shift, ang_freq_grid, axes=1)
-    )
+    phase_shift = da.exp((-J) * da.tensordot(shift, ang_freq_grid, axes=1))
     result = image * phase_shift
 
     return result
@@ -200,10 +196,8 @@ def fourier_uniform(image, size, n=-1, axis=-1):
     )
 
     # Compute uniform filter
-    uniform = dask.array.sinc(
-        size[(slice(None),) + image.ndim * (None,)] * freq_grid
-    )
-    uniform = dask.array.prod(uniform, axis=0)
+    uniform = da.sinc(size[(slice(None),) + image.ndim * (None,)] * freq_grid)
+    uniform = da.prod(uniform, axis=0)
 
     result = image * uniform
 

--- a/dask_image/ndfourier/__init__.py
+++ b/dask_image/ndfourier/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import division
 import numbers
 
 import dask.array

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -3,7 +3,7 @@
 
 import numbers
 
-import dask.array
+import dask.array as da
 import numpy as np
 
 
@@ -17,11 +17,11 @@ def _get_freq_grid(shape, chunks, dtype=float):
             not issubclass(dtype, numbers.Integral))
 
     freq_grid = [
-        dask.array.fft.fftfreq(s, chunks=c).astype(dtype)
+        da.fft.fftfreq(s, chunks=c).astype(dtype)
         for s, c in zip(shape, chunks)
     ]
-    freq_grid = dask.array.meshgrid(*freq_grid, indexing="ij")
-    freq_grid = dask.array.stack(freq_grid)
+    freq_grid = da.meshgrid(*freq_grid, indexing="ij")
+    freq_grid = da.stack(freq_grid)
 
     return freq_grid
 
@@ -46,7 +46,7 @@ def _norm_args(a, s, n=-1, axis=-1):
 
     if isinstance(s, numbers.Number):
         s = np.array(a.ndim * [s])
-    elif not isinstance(s, dask.array.Array):
+    elif not isinstance(s, da.Array):
         s = np.array(s)
 
     if issubclass(s.dtype.type, numbers.Integral):

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -4,14 +4,14 @@
 import numbers
 
 import dask.array
-import numpy
+import numpy as np
 
 
 def _get_freq_grid(shape, chunks, dtype=float):
     assert len(shape) == len(chunks)
 
     shape = tuple(shape)
-    dtype = numpy.dtype(dtype).type
+    dtype = np.dtype(dtype).type
 
     assert (issubclass(dtype, numbers.Real) and
             not issubclass(dtype, numbers.Integral))
@@ -27,12 +27,12 @@ def _get_freq_grid(shape, chunks, dtype=float):
 
 
 def _get_ang_freq_grid(shape, chunks, dtype=float):
-    dtype = numpy.dtype(dtype).type
+    dtype = np.dtype(dtype).type
 
     assert (issubclass(dtype, numbers.Real) and
             not issubclass(dtype, numbers.Integral))
 
-    pi = dtype(numpy.pi)
+    pi = dtype(np.pi)
 
     freq_grid = _get_freq_grid(shape, chunks, dtype=dtype)
     ang_freq_grid = (2 * pi) * freq_grid
@@ -45,9 +45,9 @@ def _norm_args(a, s, n=-1, axis=-1):
         a = a.astype(float)
 
     if isinstance(s, numbers.Number):
-        s = numpy.array(a.ndim * [s])
+        s = np.array(a.ndim * [s])
     elif not isinstance(s, dask.array.Array):
-        s = numpy.array(s)
+        s = np.array(s)
 
     if issubclass(s.dtype.type, numbers.Integral):
         s = s.astype(a.real.dtype)

--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -3,9 +3,8 @@
 
 import numbers
 
-import numpy
-
 import dask.array
+import numpy
 
 
 def _get_freq_grid(shape, chunks, dtype=float):

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -1,21 +1,16 @@
 # -*- coding: utf-8 -*-
 
+import warnings
 from itertools import product
-import numpy as np
 
 import dask.array as da
+import numpy as np
 from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
-
 from scipy.ndimage import affine_transform as ndimage_affine_transform
-import warnings
 
-
-from ..dispatch._dispatch_ndinterp import (
-    dispatch_affine_transform,
-    dispatch_asarray,
-)
-
+from ..dispatch._dispatch_ndinterp import (dispatch_affine_transform,
+                                           dispatch_asarray)
 
 __all__ = [
     "affine_transform",

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -168,8 +168,8 @@ def extrema(image, label_image=None, index=None):
     out_dtype = np.dtype([
         ("min_val", image.dtype),
         ("max_val", image.dtype),
-        ("min_pos", np.dtype(np.int), image.ndim),
-        ("max_pos", np.dtype(np.int), image.ndim)
+        ("min_pos", np.dtype(int), image.ndim),
+        ("max_pos", np.dtype(int), image.ndim)
     ])
     default_1d = np.zeros((1,), dtype=out_dtype)
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -5,8 +5,8 @@ import functools
 import operator
 import warnings
 
-import numpy
 import dask.array
+import numpy
 
 from . import _utils
 from ._utils import _label

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -6,7 +6,7 @@ import operator
 import warnings
 
 import dask.array
-import numpy
+import numpy as np
 
 from . import _utils
 from ._utils import _label
@@ -74,7 +74,7 @@ def area(image, label_image=None, index=None):
     """
 
     if label_image is None:
-        return dask.array.prod(numpy.array([i for i in image.shape]))
+        return dask.array.prod(np.array([i for i in image.shape]))
 
     else:
         image, label_image, index = _utils._norm_input_labels_index(
@@ -124,8 +124,8 @@ def center_of_mass(image, label_image=None, index=None):
     # This only matters if index is some array.
     index = index.T
 
-    out_dtype = numpy.dtype([("com", float, (image.ndim,))])
-    default_1d = numpy.full((1,), numpy.nan, dtype=out_dtype)
+    out_dtype = np.dtype([("com", float, (image.ndim,))])
+    default_1d = np.full((1,), np.nan, dtype=out_dtype)
 
     func = functools.partial(
         _utils._center_of_mass, shape=image.shape, dtype=out_dtype
@@ -165,13 +165,13 @@ def extrema(image, label_image=None, index=None):
         image, label_image, index
     )
 
-    out_dtype = numpy.dtype([
+    out_dtype = np.dtype([
         ("min_val", image.dtype),
         ("max_val", image.dtype),
-        ("min_pos", numpy.dtype(numpy.int), image.ndim),
-        ("max_pos", numpy.dtype(numpy.int), image.ndim)
+        ("min_pos", np.dtype(np.int), image.ndim),
+        ("max_pos", np.dtype(np.int), image.ndim)
     ])
-    default_1d = numpy.zeros((1,), dtype=out_dtype)
+    default_1d = np.zeros((1,), dtype=out_dtype)
 
     func = functools.partial(
         _utils._extrema, shape=image.shape, dtype=out_dtype
@@ -192,7 +192,7 @@ def extrema(image, label_image=None, index=None):
             pos_nd = dask.array.squeeze(pos_nd)
         elif index.ndim > 1:
             pos_nd = pos_nd.reshape(
-                (int(numpy.prod(pos_nd.shape[:-1])), pos_nd.shape[-1])
+                (int(np.prod(pos_nd.shape[:-1])), pos_nd.shape[-1])
             )
 
         extrema_lbl[pos_key] = pos_nd
@@ -287,13 +287,13 @@ def label(image, structure=None):
 
     image = dask.array.asarray(image)
 
-    labeled_blocks = numpy.empty(image.numblocks, dtype=object)
+    labeled_blocks = np.empty(image.numblocks, dtype=object)
 
     # First, label each block independently, incrementing the labels in that
     # block by the total number of labels from previous blocks. This way, each
     # block's labels are globally unique.
     block_iter = zip(
-        numpy.ndindex(*image.numblocks),
+        np.ndindex(*image.numblocks),
         map(functools.partial(operator.getitem, image),
             dask.array.core.slices_from_chunks(image.chunks))
     )
@@ -376,8 +376,8 @@ def labeled_comprehension(image,
         image, label_image, index
     )
 
-    out_dtype = numpy.dtype(out_dtype)
-    default_1d = numpy.full((1,), default, dtype=out_dtype)
+    out_dtype = np.dtype(out_dtype)
+    default_1d = np.full((1,), default, dtype=out_dtype)
 
     pass_positions = bool(pass_positions)
 
@@ -388,8 +388,8 @@ def labeled_comprehension(image,
         )
         args = (image, positions)
 
-    result = numpy.empty(index.shape, dtype=object)
-    for i in numpy.ndindex(index.shape):
+    result = np.empty(index.shape, dtype=object)
+    for i in np.ndindex(index.shape):
         lbl_mtch_i = (label_image == index[i])
         args_lbl_mtch_i = tuple(e[lbl_mtch_i] for e in args)
         result[i] = _utils._labeled_comprehension_func(
@@ -398,7 +398,7 @@ def labeled_comprehension(image,
 
     for i in range(result.ndim - 1, -1, -1):
         result2 = result[..., 0]
-        for j in numpy.ndindex(index.shape[:i]):
+        for j in np.ndindex(index.shape[:i]):
             result2[j] = dask.array.stack(result[j].tolist(), axis=0)
         result = result2
     result = result[()][..., 0]
@@ -434,7 +434,7 @@ def maximum(image, label_image=None, index=None):
     )
 
     return labeled_comprehension(
-        image, label_image, index, numpy.max, image.dtype, image.dtype.type(0)
+        image, label_image, index, np.max, image.dtype, image.dtype.type(0)
     )
 
 
@@ -471,8 +471,8 @@ def maximum_position(image, label_image=None, index=None):
     if index.shape:
         index = index.flatten()
 
-    out_dtype = numpy.dtype([("pos", int, (image.ndim,))])
-    default_1d = numpy.zeros((1,), dtype=out_dtype)
+    out_dtype = np.dtype([("pos", int, (image.ndim,))])
+    default_1d = np.zeros((1,), dtype=out_dtype)
 
     func = functools.partial(
         _utils._argmax, shape=image.shape, dtype=out_dtype
@@ -516,10 +516,10 @@ def mean(image, label_image=None, index=None):
         image, label_image, index
     )
 
-    nan = numpy.float64(numpy.nan)
+    nan = np.float64(np.nan)
 
     mean_lbl = labeled_comprehension(
-        image, label_image, index, numpy.mean, numpy.float64, nan
+        image, label_image, index, np.mean, np.float64, nan
     )
 
     return mean_lbl
@@ -552,10 +552,10 @@ def median(image, label_image=None, index=None):
         image, label_image, index
     )
 
-    nan = numpy.float64(numpy.nan)
+    nan = np.float64(np.nan)
 
     return labeled_comprehension(
-        image, label_image, index, numpy.median, numpy.float64, nan
+        image, label_image, index, np.median, np.float64, nan
     )
 
 
@@ -587,7 +587,7 @@ def minimum(image, label_image=None, index=None):
     )
 
     return labeled_comprehension(
-        image, label_image, index, numpy.min, image.dtype, image.dtype.type(0)
+        image, label_image, index, np.min, image.dtype, image.dtype.type(0)
     )
 
 
@@ -621,8 +621,8 @@ def minimum_position(image, label_image=None, index=None):
     if index.shape:
         index = index.flatten()
 
-    out_dtype = numpy.dtype([("pos", int, (image.ndim,))])
-    default_1d = numpy.zeros((1,), dtype=out_dtype)
+    out_dtype = np.dtype([("pos", int, (image.ndim,))])
+    default_1d = np.zeros((1,), dtype=out_dtype)
 
     func = functools.partial(
         _utils._argmin, shape=image.shape, dtype=out_dtype
@@ -666,10 +666,10 @@ def standard_deviation(image, label_image=None, index=None):
         image, label_image, index
     )
 
-    nan = numpy.float64(numpy.nan)
+    nan = np.float64(np.nan)
 
     std_lbl = labeled_comprehension(
-        image, label_image, index, numpy.std, numpy.float64, nan
+        image, label_image, index, np.std, np.float64, nan
     )
 
     return std_lbl
@@ -703,7 +703,7 @@ def sum_labels(image, label_image=None, index=None):
     )
 
     sum_lbl = labeled_comprehension(
-        image, label_image, index, numpy.sum, numpy.float64, numpy.float64(0)
+        image, label_image, index, np.sum, np.float64, np.float64(0)
     )
 
     return sum_lbl
@@ -742,10 +742,10 @@ def variance(image, label_image=None, index=None):
         image, label_image, index
     )
 
-    nan = numpy.float64(numpy.nan)
+    nan = np.float64(np.nan)
 
     var_lbl = labeled_comprehension(
-        image, label_image, index, numpy.var, numpy.float64, nan
+        image, label_image, index, np.var, np.float64, nan
     )
 
     return var_lbl

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -304,8 +304,8 @@ def label(image, structure=None):
         labeled_block, n = _label.block_ndi_label_delayed(input_block,
                                                           structure)
         block_label_offset = da.where(labeled_block > 0,
-                                              total,
-                                              _label.LABEL_DTYPE.type(0))
+                                      total,
+                                      _label.LABEL_DTYPE.type(0))
         labeled_block += block_label_offset
         labeled_blocks[index] = labeled_block
         total += n
@@ -711,7 +711,8 @@ def sum_labels(image, label_image=None, index=None):
 
 def sum(image, label_image=None, index=None):
     """DEPRECATED FUNCTION. Use `sum_labels` instead."""
-    warnings.warn("DEPRECATED FUNCTION. Use `sum_labels` instead.", DeprecationWarning)
+    warnings.warn("DEPRECATED FUNCTION. Use `sum_labels` instead.",
+                  DeprecationWarning)
     return sum_labels(image, label_image=label_image, index=index)
 
 

--- a/dask_image/ndmeasure/_utils/__init__.py
+++ b/dask_image/ndmeasure/_utils/__init__.py
@@ -1,15 +1,9 @@
 # -*- coding: utf-8 -*-
-
-
-from __future__ import division
-
 import warnings
-
-import numpy
 
 import dask
 import dask.array
-
+import numpy
 
 try:
     from dask.array import blockwise as da_blockwise

--- a/dask_image/ndmeasure/_utils/__init__.py
+++ b/dask_image/ndmeasure/_utils/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 import dask
 import dask.array
-import numpy
+import numpy as np
 
 try:
     from dask.array import blockwise as da_blockwise
@@ -60,8 +60,8 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
     indices = [
         dask.array.arange(
             0,
-            numpy.prod(dimensions[i:], dtype=dtype),
-            numpy.prod(dimensions[i + 1:], dtype=dtype),
+            np.prod(dimensions[i:], dtype=dtype),
+            np.prod(dimensions[i + 1:], dtype=dtype),
             dtype=dtype,
             chunks=c
         )
@@ -82,9 +82,9 @@ def _argmax(a, positions, shape, dtype):
     Find original array position corresponding to the maximum.
     """
 
-    result = numpy.empty((1,), dtype=dtype)
+    result = np.empty((1,), dtype=dtype)
 
-    pos_nd = numpy.unravel_index(positions[numpy.argmax(a)], shape)
+    pos_nd = np.unravel_index(positions[np.argmax(a)], shape)
     for i, pos_nd_i in enumerate(pos_nd):
         result["pos"][0, i] = pos_nd_i
 
@@ -96,9 +96,9 @@ def _argmin(a, positions, shape, dtype):
     Find original array position corresponding to the minimum.
     """
 
-    result = numpy.empty((1,), dtype=dtype)
+    result = np.empty((1,), dtype=dtype)
 
-    pos_nd = numpy.unravel_index(positions[numpy.argmin(a)], shape)
+    pos_nd = np.unravel_index(positions[np.argmin(a)], shape)
     for i, pos_nd_i in enumerate(pos_nd):
         result["pos"][0, i] = pos_nd_i
 
@@ -110,14 +110,14 @@ def _center_of_mass(a, positions, shape, dtype):
     Find the center of mass for each ROI.
     """
 
-    result = numpy.empty((1,), dtype=dtype)
+    result = np.empty((1,), dtype=dtype)
 
-    positions_nd = numpy.unravel_index(positions, shape)
-    a_sum = numpy.sum(a)
+    positions_nd = np.unravel_index(positions, shape)
+    a_sum = np.sum(a)
 
-    a_wt_i = numpy.empty(a.shape)
+    a_wt_i = np.empty(a.shape)
     for i, pos_nd_i in enumerate(positions_nd):
-        a_wt_sum_i = numpy.multiply(a, pos_nd_i, out=a_wt_i).sum()
+        a_wt_sum_i = np.multiply(a, pos_nd_i, out=a_wt_i).sum()
         result["com"][0, i] = a_wt_sum_i / a_sum
 
     return result[0]
@@ -128,16 +128,16 @@ def _extrema(a, positions, shape, dtype):
     Find minimum and maximum as well as positions for both.
     """
 
-    result = numpy.empty((1,), dtype=dtype)
+    result = np.empty((1,), dtype=dtype)
 
-    int_min_pos = numpy.argmin(a)
-    int_max_pos = numpy.argmax(a)
+    int_min_pos = np.argmin(a)
+    int_max_pos = np.argmax(a)
 
     result["min_val"] = a[int_min_pos]
     result["max_val"] = a[int_max_pos]
 
-    min_pos_nd = numpy.unravel_index(positions[int_min_pos], shape)
-    max_pos_nd = numpy.unravel_index(positions[int_max_pos], shape)
+    min_pos_nd = np.unravel_index(positions[int_min_pos], shape)
+    max_pos_nd = np.unravel_index(positions[int_max_pos], shape)
     for i in range(len(shape)):
         result["min_pos"][0, i] = min_pos_nd[i]
         result["max_pos"][0, i] = max_pos_nd[i]
@@ -155,7 +155,7 @@ def _histogram(image,
     Also reformats the arguments.
     """
 
-    return numpy.histogram(image, bins, (min, max))[0]
+    return np.histogram(image, bins, (min, max))[0]
 
 
 @dask.delayed
@@ -171,7 +171,7 @@ def _labeled_comprehension_delayed(func,
     computation should not occur.
     """
 
-    result = numpy.empty((1,), dtype=out_dtype)
+    result = np.empty((1,), dtype=out_dtype)
 
     if a.size:
         if positions is None:

--- a/dask_image/ndmeasure/_utils/__init__.py
+++ b/dask_image/ndmeasure/_utils/__init__.py
@@ -2,7 +2,7 @@
 import warnings
 
 import dask
-import dask.array
+import dask.array as da
 import numpy as np
 
 try:
@@ -16,19 +16,19 @@ def _norm_input_labels_index(image, label_image=None, index=None):
     Normalize arguments to a standard form.
     """
 
-    image = dask.array.asarray(image)
+    image = da.asarray(image)
 
     if label_image is None:
-        label_image = dask.array.ones(
+        label_image = da.ones(
             image.shape, dtype=int, chunks=image.chunks,
         )
-        index = dask.array.ones(tuple(), dtype=int, chunks=tuple())
+        index = da.ones(tuple(), dtype=int, chunks=tuple())
     elif index is None:
         label_image = (label_image > 0).astype(int)
-        index = dask.array.ones(tuple(), dtype=int, chunks=tuple())
+        index = da.ones(tuple(), dtype=int, chunks=tuple())
 
-    label_image = dask.array.asarray(label_image)
-    index = dask.array.asarray(index)
+    label_image = da.asarray(label_image)
+    index = da.asarray(index)
 
     if index.ndim > 1:
         warnings.warn(
@@ -58,7 +58,7 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
     """
 
     indices = [
-        dask.array.arange(
+        da.arange(
             0,
             np.prod(dimensions[i:], dtype=dtype),
             np.prod(dimensions[i + 1:], dtype=dtype),
@@ -195,7 +195,7 @@ def _labeled_comprehension_func(func,
     Ensures the result is a proper Dask Array and the computation delayed.
     """
 
-    return dask.array.from_delayed(
+    return da.from_delayed(
         _labeled_comprehension_delayed(func, out_dtype, default, a, positions),
         (1,),
         out_dtype

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -44,10 +44,10 @@ def relabel_blocks(block_labeled, new_labeling):
     """
     new_labeling = new_labeling.astype(LABEL_DTYPE)
     relabeled = da.map_blocks(operator.getitem,
-                                      new_labeling,
-                                      block_labeled,
-                                      dtype=LABEL_DTYPE,
-                                      chunks=block_labeled.chunks)
+                              new_labeling,
+                              block_labeled,
+                              dtype=LABEL_DTYPE,
+                              chunks=block_labeled.chunks)
     return relabeled
 
 
@@ -112,9 +112,7 @@ def _across_block_label_grouping_delayed(face, structure):
     """Delayed version of :func:`_across_block_label_grouping`."""
     _across_block_label_grouping_ = dask.delayed(_across_block_label_grouping)
     grouped = _across_block_label_grouping_(face, structure)
-    return da.from_delayed(grouped,
-                                   shape=(2, np.nan),
-                                   dtype=LABEL_DTYPE)
+    return da.from_delayed(grouped, shape=(2, np.nan), dtype=LABEL_DTYPE)
 
 
 @dask.delayed
@@ -229,7 +227,7 @@ def block_ndi_label_delayed(block, structure):
     labeled_block, n = label(block, structure=structure)
     n = dask.delayed(LABEL_DTYPE.type)(n)
     labeled = da.from_delayed(labeled_block, shape=block.shape,
-                                      dtype=LABEL_DTYPE)
+                              dtype=LABEL_DTYPE)
     n = da.from_delayed(n, shape=(), dtype=LABEL_DTYPE)
     return labeled, n
 

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -2,13 +2,12 @@
 
 import operator
 
+import dask
+import dask.array
 import numpy
 import scipy.ndimage
 import scipy.sparse
 import scipy.sparse.csgraph
-
-import dask
-import dask.array
 
 
 def _get_ndimage_label_dtype():

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -4,7 +4,7 @@ import operator
 
 import dask
 import dask.array
-import numpy
+import numpy as np
 import scipy.ndimage
 import scipy.sparse
 import scipy.sparse.csgraph
@@ -18,7 +18,7 @@ LABEL_DTYPE = _get_ndimage_label_dtype()
 
 
 def _get_connected_components_dtype():
-    a = numpy.empty((0, 0), dtype=int)
+    a = np.empty((0, 0), dtype=int)
     return scipy.sparse.csgraph.connected_components(a)[1].dtype
 
 
@@ -53,10 +53,10 @@ def relabel_blocks(block_labeled, new_labeling):
 
 def _unique_axis(a, axis=0):
     """Find unique subarrays in axis in N-D array."""
-    at = numpy.ascontiguousarray(a.swapaxes(0, axis))
-    dt = numpy.dtype([("values", at.dtype, at.shape[1:])])
+    at = np.ascontiguousarray(a.swapaxes(0, axis))
+    dt = np.dtype([("values", at.dtype, at.shape[1:])])
     atv = at.view(dt)
-    r = numpy.unique(atv)["values"].swapaxes(0, axis)
+    r = np.unique(atv)["values"].swapaxes(0, axis)
     return r
 
 
@@ -85,26 +85,26 @@ def _across_block_label_grouping(face, structure):
 
     Examples
     --------
-    >>> face = numpy.array([[1, 1, 0, 2, 2, 0, 8],
+    >>> face = np.array([[1, 1, 0, 2, 2, 0, 8],
     ...                     [0, 7, 7, 7, 7, 0, 9]])
-    >>> structure = numpy.ones((3, 3), dtype=bool)
+    >>> structure = np.ones((3, 3), dtype=bool)
     >>> _across_block_label_grouping(face, structure)
     array([[1, 2, 8],
-           [2, 7, 9]], dtype=numpy.int32)
+           [2, 7, 9]], dtype=np.int32)
 
     This shows that 1-2 are connected, 2-7 are connected, and 8-9 are
     connected. The resulting graph is (1-2-7), (8-9).
     """
     common_labels = scipy.ndimage.label(face, structure)[0]
-    matching = numpy.stack((common_labels.ravel(), face.ravel()), axis=1)
+    matching = np.stack((common_labels.ravel(), face.ravel()), axis=1)
     unique_matching = _unique_axis(matching)
-    valid = numpy.all(unique_matching, axis=1)
+    valid = np.all(unique_matching, axis=1)
     unique_valid_matching = unique_matching[valid]
     common_labels, labels = unique_valid_matching.T
-    in_group = numpy.flatnonzero(numpy.diff(common_labels) == 0)
-    i = numpy.take(labels, in_group)
-    j = numpy.take(labels, in_group + 1)
-    grouped = numpy.stack((i, j), axis=0)
+    in_group = np.flatnonzero(np.diff(common_labels) == 0)
+    i = np.take(labels, in_group)
+    j = np.take(labels, in_group + 1)
+    grouped = np.stack((i, j), axis=0)
     return grouped
 
 
@@ -113,14 +113,14 @@ def _across_block_label_grouping_delayed(face, structure):
     _across_block_label_grouping_ = dask.delayed(_across_block_label_grouping)
     grouped = _across_block_label_grouping_(face, structure)
     return dask.array.from_delayed(grouped,
-                                   shape=(2, numpy.nan),
+                                   shape=(2, np.nan),
                                    dtype=LABEL_DTYPE)
 
 
 @dask.delayed
 def _to_csr_matrix(i, j, n):
     """Using i and j as coo-format coordinates, return csr matrix."""
-    v = numpy.ones_like(i)
+    v = np.ones_like(i)
     mat = scipy.sparse.coo_matrix((v, (i, j)), shape=(n, n))
     return mat.tocsr()
 
@@ -242,4 +242,4 @@ def connected_components_delayed(csr_matrix):
     """
     conn_comp = dask.delayed(scipy.sparse.csgraph.connected_components, nout=2)
     return dask.array.from_delayed(conn_comp(csr_matrix, directed=False)[1],
-                                   shape=(numpy.nan,), dtype=CONN_COMP_DTYPE)
+                                   shape=(np.nan,), dtype=CONN_COMP_DTYPE)

--- a/dask_image/ndmorph/__init__.py
+++ b/dask_image/ndmorph/__init__.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 import scipy.ndimage
 
-from . import _utils
-from . import _ops
-from ..dispatch._dispatch_ndmorph import (
-    dispatch_binary_dilation,
-    dispatch_binary_erosion)
+from ..dispatch._dispatch_ndmorph import (dispatch_binary_dilation,
+                                          dispatch_binary_erosion)
+from . import _ops, _utils
 
 __all__ = [
     "binary_closing",

--- a/dask_image/ndmorph/__init__.py
+++ b/dask_image/ndmorph/__init__.py
@@ -27,7 +27,7 @@ def binary_closing(image,
     iterations = _utils._get_iterations(iterations)
     origin = _utils._get_origin(structure.shape, origin)
 
-    kwargs =  dict(
+    kwargs = dict(
         structure=structure,
         iterations=iterations,
         origin=origin,
@@ -105,7 +105,7 @@ def binary_opening(image,
     iterations = _utils._get_iterations(iterations)
     origin = _utils._get_origin(structure.shape, origin)
 
-    kwargs =  dict(
+    kwargs = dict(
         structure=structure,
         iterations=iterations,
         origin=origin,

--- a/dask_image/ndmorph/_ops.py
+++ b/dask_image/ndmorph/_ops.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-import dask.array
+import dask.array as da
 
 from . import _utils
 
@@ -36,7 +36,7 @@ def _binary_op(func,
             origin=origin,
             **kwargs
         )
-        result = dask.array.where(mask, iter_result, result)
+        result = da.where(mask, iter_result, result)
         result._meta = image._meta.astype(bool)
 
     return result

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -5,7 +5,6 @@ import numbers
 
 import dask.array as da
 import numpy as np
-import scipy.ndimage
 
 from ..dispatch._dispatch_ndmorph import dispatch_binary_structure
 from ..ndfilters._utils import (_get_depth, _get_depth_boundary, _get_origin,

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -4,7 +4,7 @@
 import numbers
 
 import dask.array
-import numpy
+import numpy as np
 import scipy.ndimage
 
 from ..dispatch._dispatch_ndmorph import dispatch_binary_structure
@@ -27,7 +27,7 @@ def _get_structure(image, structure):
             raise RuntimeError(
                 "`structure` must have the same rank as `image`."
             )
-        if not issubclass(structure.dtype.type, numpy.bool8):
+        if not issubclass(structure.dtype.type, np.bool8):
             structure = (structure != 0)
     else:
         raise TypeError("`structure` must be an array.")
@@ -49,7 +49,7 @@ def _get_iterations(iterations):
 def _get_dtype(a):
     # Get the dtype of a value or an array.
     # Even handle non-NumPy types.
-    return getattr(a, "dtype", numpy.dtype(type(a)))
+    return getattr(a, "dtype", np.dtype(type(a)))
 
 
 def _get_mask(image, mask):
@@ -57,12 +57,12 @@ def _get_mask(image, mask):
         mask = True
 
     mask_type = _get_dtype(mask).type
-    if isinstance(mask, (numpy.ndarray, dask.array.Array)):
+    if isinstance(mask, (np.ndarray, dask.array.Array)):
         if mask.shape != image.shape:
             raise RuntimeError("`mask` must have the same shape as `image`.")
-        if not issubclass(mask_type, numpy.bool8):
+        if not issubclass(mask_type, np.bool8):
             mask = (mask != 0)
-    elif issubclass(mask_type, numpy.bool8):
+    elif issubclass(mask_type, np.bool8):
         mask = bool(mask)
     else:
         raise TypeError("`mask` must be a Boolean or an array.")

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -3,18 +3,13 @@
 
 import numbers
 
+import dask.array
 import numpy
 import scipy.ndimage
 
-import dask.array
-
 from ..dispatch._dispatch_ndmorph import dispatch_binary_structure
-from ..ndfilters._utils import (
-    _update_wrapper,
-    _get_depth_boundary,
-    _get_origin,
-    _get_depth
-)
+from ..ndfilters._utils import (_get_depth, _get_depth_boundary, _get_origin,
+                                _update_wrapper)
 
 _update_wrapper = _update_wrapper
 _get_depth_boundary = _get_depth_boundary

--- a/dask_image/ndmorph/_utils.py
+++ b/dask_image/ndmorph/_utils.py
@@ -3,7 +3,7 @@
 
 import numbers
 
-import dask.array
+import dask.array as da
 import numpy as np
 import scipy.ndimage
 
@@ -57,7 +57,7 @@ def _get_mask(image, mask):
         mask = True
 
     mask_type = _get_dtype(mask).type
-    if isinstance(mask, (np.ndarray, dask.array.Array)):
+    if isinstance(mask, (np.ndarray, da.Array)):
         if mask.shape != image.shape:
             raise RuntimeError("`mask` must have the same shape as `image`.")
         if not issubclass(mask_type, np.bool8):

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 import tifffile
 
-import dask.array.utils as dau
+import dask.array as da
 import dask_image.imread
 
 
@@ -94,4 +94,4 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype, is_pa
     else:
         assert (shape[0] % nframes) == d.chunks[0][-1]
 
-    dau.assert_eq(a, d)
+    da.utils.assert_eq(a, d)

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -61,7 +61,7 @@ def test_errs_imread(err_type, nframes):
         False,
     ]
 )
-def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype, is_pathlib_Path):
+def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype, is_pathlib_Path):  # noqa: E501
     np.random.seed(seed)
 
     dirpth = tmpdir.mkdir("test_imread")

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-
-from __future__ import absolute_import
-
 import numbers
 import pathlib
 

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -6,14 +6,14 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 @pytest.mark.parametrize(
     "da_func",
     [
-        (da_ndf.convolve),
-        (da_ndf.correlate),
+        (dask_image.ndfilters.convolve),
+        (dask_image.ndfilters.correlate),
     ]
 )
 @pytest.mark.parametrize(
@@ -46,8 +46,8 @@ def test_convolutions_params(da_func,
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.convolve,
-        da_ndf.correlate,
+        dask_image.ndfilters.convolve,
+        dask_image.ndfilters.correlate,
     ]
 )
 def test_convolutions_shape_type(da_func):
@@ -66,8 +66,8 @@ def test_convolutions_shape_type(da_func):
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.convolve,
-        da_ndf.correlate,
+        dask_image.ndfilters.convolve,
+        dask_image.ndfilters.correlate,
     ]
 )
 def test_convolutions_comprehensions(da_func):
@@ -88,8 +88,8 @@ def test_convolutions_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.convolve, da_ndf.convolve),
-        (scipy.ndimage.filters.correlate, da_ndf.correlate),
+        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
     ]
 )
 @pytest.mark.parametrize(
@@ -117,8 +117,8 @@ def test_convolutions_identity(sp_func,
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.convolve, da_ndf.convolve),
-        (scipy.ndimage.filters.correlate, da_ndf.correlate),
+        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -11,9 +11,6 @@ import dask.array.utils as dau
 import dask_image.ndfilters as da_ndf
 
 
-assert dask
-
-
 @pytest.mark.parametrize(
     "da_func",
     [

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -4,9 +4,7 @@ import pytest
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
 
@@ -83,8 +81,8 @@ def test_convolutions_comprehensions(da_func):
     l2s = [da_func(d[i], weights) for i in range(len(d))]
     l2c = [da_func(d[i], weights)[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 @pytest.mark.parametrize(
@@ -106,11 +104,11 @@ def test_convolutions_identity(sp_func,
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         d, da_func(d, weights)
     )
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, weights),
         da_func(d, weights)
     )
@@ -148,7 +146,7 @@ def test_convolutions_compare(sp_func,
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(
             a, weights, origin=origin
         ),

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -88,8 +88,8 @@ def test_convolutions_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.convolve, da_ndf.convolve),
-        (sp_ndf.correlate, da_ndf.correlate),
+        (scipy.ndimage.filters.convolve, da_ndf.convolve),
+        (scipy.ndimage.filters.correlate, da_ndf.correlate),
     ]
 )
 @pytest.mark.parametrize(
@@ -117,8 +117,8 @@ def test_convolutions_identity(sp_func,
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.convolve, da_ndf.convolve),
-        (sp_ndf.correlate, da_ndf.correlate),
+        (scipy.ndimage.filters.convolve, da_ndf.convolve),
+        (scipy.ndimage.filters.correlate, da_ndf.correlate),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__diff.py
+++ b/tests/test_dask_image/test_ndfilters/test__diff.py
@@ -10,9 +10,6 @@ import dask.array.utils as dau
 import dask_image.ndfilters as da_ndf
 
 
-assert dask
-
-
 def test_laplace_comprehensions():
     np.random.seed(0)
 

--- a/tests/test_dask_image/test_ndfilters/test__diff.py
+++ b/tests/test_dask_image/test_ndfilters/test__diff.py
@@ -3,9 +3,7 @@
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
 
@@ -19,8 +17,8 @@ def test_laplace_comprehensions():
     l2s = [da_ndf.laplace(d[i]) for i in range(len(d))]
     l2c = [da_ndf.laplace(d[i])[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 def test_laplace_compare():
@@ -28,7 +26,7 @@ def test_laplace_compare():
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(5, 5, 6))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_ndf.laplace(a),
         da_ndf.laplace(d)
     )

--- a/tests/test_dask_image/test_ndfilters/test__diff.py
+++ b/tests/test_dask_image/test_ndfilters/test__diff.py
@@ -5,7 +5,7 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 def test_laplace_comprehensions():
@@ -14,8 +14,8 @@ def test_laplace_comprehensions():
     a = np.random.random((3, 12, 14))
     d = da.from_array(a, chunks=(3, 6, 7))
 
-    l2s = [da_ndf.laplace(d[i]) for i in range(len(d))]
-    l2c = [da_ndf.laplace(d[i])[None] for i in range(len(d))]
+    l2s = [dask_image.ndfilters.laplace(d[i]) for i in range(len(d))]
+    l2c = [dask_image.ndfilters.laplace(d[i])[None] for i in range(len(d))]
 
     da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
     da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
@@ -28,5 +28,5 @@ def test_laplace_compare():
 
     da.utils.assert_eq(
         scipy.ndimage.filters.laplace(a),
-        da_ndf.laplace(d)
+        dask_image.ndfilters.laplace(d)
     )

--- a/tests/test_dask_image/test_ndfilters/test__diff.py
+++ b/tests/test_dask_image/test_ndfilters/test__diff.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 

--- a/tests/test_dask_image/test_ndfilters/test__diff.py
+++ b/tests/test_dask_image/test_ndfilters/test__diff.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -27,6 +27,6 @@ def test_laplace_compare():
     d = da.from_array(a, chunks=(5, 5, 6))
 
     da.utils.assert_eq(
-        sp_ndf.laplace(a),
+        scipy.ndimage.filters.laplace(a),
         da_ndf.laplace(d)
     )

--- a/tests/test_dask_image/test_ndfilters/test__edge.py
+++ b/tests/test_dask_image/test_ndfilters/test__edge.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -66,8 +66,8 @@ def test_edge_comprehensions(da_func):
 @pytest.mark.parametrize(
     "da_func, sp_func",
     [
-        (da_ndf.prewitt, sp_ndf.prewitt),
-        (da_ndf.sobel, sp_ndf.sobel),
+        (da_ndf.prewitt, scipy.ndimage.filters.prewitt),
+        (da_ndf.sobel, scipy.ndimage.filters.sobel),
     ]
 )
 def test_edge_func_compare(da_func, sp_func, axis):

--- a/tests/test_dask_image/test_ndfilters/test__edge.py
+++ b/tests/test_dask_image/test_ndfilters/test__edge.py
@@ -11,9 +11,6 @@ import dask.array.utils as dau
 import dask_image.ndfilters as da_ndf
 
 
-assert dask
-
-
 @pytest.mark.parametrize(
     "err_type, axis",
     [

--- a/tests/test_dask_image/test_ndfilters/test__edge.py
+++ b/tests/test_dask_image/test_ndfilters/test__edge.py
@@ -4,9 +4,7 @@ import pytest
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
 
@@ -50,8 +48,8 @@ def test_edge_comprehensions(da_func):
     l2s = [da_func(d[i]) for i in range(len(d))]
     l2c = [da_func(d[i])[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 @pytest.mark.parametrize(
@@ -77,7 +75,7 @@ def test_edge_func_compare(da_func, sp_func, axis):
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(5, 5, 6))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, axis),
         da_func(d, axis)
     )

--- a/tests/test_dask_image/test_ndfilters/test__edge.py
+++ b/tests/test_dask_image/test_ndfilters/test__edge.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 

--- a/tests/test_dask_image/test_ndfilters/test__edge.py
+++ b/tests/test_dask_image/test_ndfilters/test__edge.py
@@ -6,7 +6,7 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 @pytest.mark.parametrize(
@@ -20,8 +20,8 @@ import dask_image.ndfilters as da_ndf
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.prewitt,
-        da_ndf.sobel,
+        dask_image.ndfilters.prewitt,
+        dask_image.ndfilters.sobel,
     ]
 )
 def test_edge_func_params(da_func, err_type, axis):
@@ -35,8 +35,8 @@ def test_edge_func_params(da_func, err_type, axis):
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.prewitt,
-        da_ndf.sobel,
+        dask_image.ndfilters.prewitt,
+        dask_image.ndfilters.sobel,
     ]
 )
 def test_edge_comprehensions(da_func):
@@ -66,8 +66,8 @@ def test_edge_comprehensions(da_func):
 @pytest.mark.parametrize(
     "da_func, sp_func",
     [
-        (da_ndf.prewitt, scipy.ndimage.filters.prewitt),
-        (da_ndf.sobel, scipy.ndimage.filters.sobel),
+        (dask_image.ndfilters.prewitt, scipy.ndimage.filters.prewitt),
+        (dask_image.ndfilters.sobel, scipy.ndimage.filters.sobel),
     ]
 )
 def test_edge_func_compare(da_func, sp_func, axis):

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -6,7 +6,7 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 @pytest.mark.parametrize(
@@ -21,9 +21,9 @@ import dask_image.ndfilters as da_ndf
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.gaussian_filter,
-        da_ndf.gaussian_gradient_magnitude,
-        da_ndf.gaussian_laplace,
+        dask_image.ndfilters.gaussian_filter,
+        dask_image.ndfilters.gaussian_gradient_magnitude,
+        dask_image.ndfilters.gaussian_laplace,
     ]
 )
 def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
@@ -49,7 +49,7 @@ def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.gaussian_filter, da_ndf.gaussian_filter),
+        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),
     ]
 )
 def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
@@ -76,9 +76,9 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.gaussian_filter,
-        da_ndf.gaussian_gradient_magnitude,
-        da_ndf.gaussian_laplace,
+        dask_image.ndfilters.gaussian_filter,
+        dask_image.ndfilters.gaussian_gradient_magnitude,
+        dask_image.ndfilters.gaussian_laplace,
     ]
 )
 def test_gaussian_filter_shape_type(da_func):
@@ -98,9 +98,9 @@ def test_gaussian_filter_shape_type(da_func):
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.gaussian_filter,
-        da_ndf.gaussian_gradient_magnitude,
-        da_ndf.gaussian_laplace,
+        dask_image.ndfilters.gaussian_filter,
+        dask_image.ndfilters.gaussian_gradient_magnitude,
+        dask_image.ndfilters.gaussian_laplace,
     ]
 )
 def test_gaussian_filter_comprehensions(da_func):
@@ -132,11 +132,11 @@ def test_gaussian_filter_comprehensions(da_func):
     "sp_func, da_func",
     [
         (scipy.ndimage.filters.gaussian_filter,
-         da_ndf.gaussian_filter),
+         dask_image.ndfilters.gaussian_filter),
         (scipy.ndimage.filters.gaussian_gradient_magnitude,
-         da_ndf.gaussian_gradient_magnitude),
+         dask_image.ndfilters.gaussian_gradient_magnitude),
         (scipy.ndimage.filters.gaussian_laplace,
-         da_ndf.gaussian_laplace),
+         dask_image.ndfilters.gaussian_laplace),
     ]
 )
 def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
@@ -176,7 +176,7 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.gaussian_filter, da_ndf.gaussian_filter),
+        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),
     ]
 )
 def test_gaussian_derivative_filters_compare(sp_func, da_func,

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -11,9 +11,6 @@ import dask.array.utils as dau
 import dask_image.ndfilters as da_ndf
 
 
-assert dask
-
-
 @pytest.mark.parametrize(
     "err_type, sigma, truncate",
     [

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -49,7 +49,7 @@ def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),
+        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),  # noqa: E501
     ]
 )
 def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
@@ -176,7 +176,7 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),
+        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),  # noqa: E501
     ]
 )
 def test_gaussian_derivative_filters_compare(sp_func, da_func,

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -49,7 +49,7 @@ def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+        (scipy.ndimage.filters.gaussian_filter, da_ndf.gaussian_filter),
     ]
 )
 def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
@@ -131,11 +131,11 @@ def test_gaussian_filter_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.gaussian_filter,
+        (scipy.ndimage.filters.gaussian_filter,
          da_ndf.gaussian_filter),
-        (sp_ndf.gaussian_gradient_magnitude,
+        (scipy.ndimage.filters.gaussian_gradient_magnitude,
          da_ndf.gaussian_gradient_magnitude),
-        (sp_ndf.gaussian_laplace,
+        (scipy.ndimage.filters.gaussian_laplace,
          da_ndf.gaussian_laplace),
     ]
 )
@@ -176,7 +176,7 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.gaussian_filter, da_ndf.gaussian_filter),
+        (scipy.ndimage.filters.gaussian_filter, da_ndf.gaussian_filter),
     ]
 )
 def test_gaussian_derivative_filters_compare(sp_func, da_func,

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -4,9 +4,7 @@ import pytest
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
 
@@ -65,11 +63,11 @@ def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
             "\n\nxref: https://github.com/scipy/scipy/issues/7364"
         )
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         d, da_func(d, sigma, order, truncate=truncate)
     )
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, sigma, order, truncate=truncate),
         da_func(d, sigma, order, truncate=truncate)
     )
@@ -116,8 +114,8 @@ def test_gaussian_filter_comprehensions(da_func):
     l2s = [da_wfunc(d[i]) for i in range(len(d))]
     l2c = [da_wfunc(d[i])[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 @pytest.mark.parametrize(
@@ -146,7 +144,7 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(50, 55))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, sigma, truncate=truncate),
         da_func(d, sigma, truncate=truncate)
     )
@@ -187,7 +185,7 @@ def test_gaussian_derivative_filters_compare(sp_func, da_func,
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(50, 55))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, sigma, order, truncate=truncate),
         da_func(d, sigma, order, truncate=truncate)
     )

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -6,14 +6,14 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.generic_filter,
-    ]
+        dask_image.ndfilters.generic_filter,
+    ],
 )
 @pytest.mark.parametrize(
     "err_type, function, size, footprint, origin",
@@ -30,32 +30,23 @@ import dask_image.ndfilters as da_ndf
         (ValueError, lambda x: x, 1, None, 1),
         (TypeError, lambda x: x, 1, None, 0.0),
         (TypeError, lambda x: x, 1, None, (0.0, 0.0)),
-        (TypeError, lambda x: x, 1, None, 1+0j),
-        (TypeError, lambda x: x, 1, None, (0+0j, 1+0j)),
-    ]
+        (TypeError, lambda x: x, 1, None, 1 + 0j),
+        (TypeError, lambda x: x, 1, None, (0 + 0j, 1 + 0j)),
+    ],
 )
-def test_generic_filters_params(da_func,
-                                err_type,
-                                function,
-                                size,
-                                footprint,
-                                origin):
+def test_generic_filters_params(da_func, err_type, function, size, footprint, origin):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
     with pytest.raises(err_type):
-        da_func(d,
-                function,
-                size=size,
-                footprint=footprint,
-                origin=origin)
+        da_func(d, function, size=size, footprint=footprint, origin=origin)
 
 
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.generic_filter,
-    ]
+        dask_image.ndfilters.generic_filter,
+    ],
 )
 def test_generic_filter_shape_type(da_func):
     function = lambda x: x  # noqa: E731
@@ -74,8 +65,8 @@ def test_generic_filter_shape_type(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.generic_filter, da_ndf.generic_filter),
-    ]
+        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),
+    ],
 )
 @pytest.mark.parametrize(
     "function, size, footprint",
@@ -83,19 +74,13 @@ def test_generic_filter_shape_type(da_func):
         (lambda x: x, 1, None),
         (lambda x: x, (1, 1), None),
         (lambda x: x, None, np.ones((1, 1))),
-    ]
+    ],
 )
-def test_generic_filter_identity(sp_func,
-                                 da_func,
-                                 function,
-                                 size,
-                                 footprint):
+def test_generic_filter_identity(sp_func, da_func, function, size, footprint):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    da.utils.assert_eq(
-        d, da_func(d, function, size=size, footprint=footprint)
-    )
+    da.utils.assert_eq(d, da_func(d, function, size=size, footprint=footprint))
 
     da.utils.assert_eq(
         sp_func(a, function, size=size, footprint=footprint),
@@ -106,8 +91,8 @@ def test_generic_filter_identity(sp_func,
 @pytest.mark.parametrize(
     "da_func",
     [
-        da_ndf.generic_filter,
-    ]
+        dask_image.ndfilters.generic_filter,
+    ],
 )
 def test_generic_filter_comprehensions(da_func):
     da_wfunc = lambda arr: da_func(arr, lambda x: x, 1)  # noqa: E731
@@ -127,106 +112,47 @@ def test_generic_filter_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.generic_filter, da_ndf.generic_filter),
-    ]
+        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),
+    ],
 )
 @pytest.mark.parametrize(
     "function, size, footprint, origin",
     [
+        (lambda x: (np.array(x) ** 2).sum(), 2, None, 0),
+        (lambda x: (np.array(x) ** 2).sum(), None, np.ones((2, 3)), 0),
+        (lambda x: (np.array(x) ** 2).sum(), None, np.ones((2, 3)), (0, 1)),
+        (lambda x: (np.array(x) ** 2).sum(), None, np.ones((2, 3)), (0, -1)),
         (
-            lambda x: (np.array(x)**2).sum(),
-            2,
+            lambda x: (np.array(x) ** 2).sum(),
             None,
-            0
+            (np.mgrid[-2 : 2 + 1, -2 : 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
+            0,
         ),
         (
-            lambda x: (np.array(x)**2).sum(),
+            lambda x: (np.array(x) ** 2).sum(),
             None,
-            np.ones((2, 3)),
-            0
+            (np.mgrid[-2 : 2 + 1, -2 : 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
+            (1, 2),
         ),
         (
-            lambda x: (np.array(x)**2).sum(),
+            lambda x: (np.array(x) ** 2).sum(),
             None,
-            np.ones((2, 3)),
-            (0, 1)
+            (np.mgrid[-2 : 2 + 1, -2 : 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
+            (-1, -2),
         ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            None,
-            np.ones((2, 3)),
-            (0, -1)
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            None,
-            (np.mgrid[-2: 2+1, -2: 2+1]**2).sum(axis=0) < 2.5**2,
-            0
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            None,
-            (np.mgrid[-2: 2+1, -2: 2+1]**2).sum(axis=0) < 2.5**2,
-            (1, 2)
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            None,
-            (np.mgrid[-2: 2+1, -2: 2+1]**2).sum(axis=0) < 2.5**2,
-            (-1, -2)
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            5,
-            None,
-            0
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            7,
-            None,
-            0
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            8,
-            None,
-            0
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            10,
-            None,
-            0
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            5,
-            None,
-            2
-        ),
-        (
-            lambda x: (np.array(x)**2).sum(),
-            5,
-            None,
-            -2
-        ),
-    ]
+        (lambda x: (np.array(x) ** 2).sum(), 5, None, 0),
+        (lambda x: (np.array(x) ** 2).sum(), 7, None, 0),
+        (lambda x: (np.array(x) ** 2).sum(), 8, None, 0),
+        (lambda x: (np.array(x) ** 2).sum(), 10, None, 0),
+        (lambda x: (np.array(x) ** 2).sum(), 5, None, 2),
+        (lambda x: (np.array(x) ** 2).sum(), 5, None, -2),
+    ],
 )
-def test_generic_filter_compare(sp_func,
-                                da_func,
-                                function,
-                                size,
-                                footprint,
-                                origin):
+def test_generic_filter_compare(sp_func, da_func, function, size, footprint, origin):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
     da.utils.assert_eq(
-        sp_func(
-            a, function, size=size, footprint=footprint, origin=origin
-        ),
-        da_func(
-            d, function, size=size, footprint=footprint, origin=origin
-        )
+        sp_func(a, function, size=size, footprint=footprint, origin=origin),
+        da_func(d, function, size=size, footprint=footprint, origin=origin),
     )

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -11,9 +11,6 @@ import dask.array.utils as dau
 import dask_image.ndfilters as da_ndf
 
 
-assert dask
-
-
 @pytest.mark.parametrize(
     "da_func",
     [

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -34,7 +34,8 @@ import dask_image.ndfilters
         (TypeError, lambda x: x, 1, None, (0 + 0j, 1 + 0j)),
     ],
 )
-def test_generic_filters_params(da_func, err_type, function, size, footprint, origin):
+def test_generic_filters_params(da_func, err_type, function, size, footprint,
+                                origin):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
@@ -65,7 +66,7 @@ def test_generic_filter_shape_type(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),
+        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),  # noqa: E501
     ],
 )
 @pytest.mark.parametrize(
@@ -112,7 +113,7 @@ def test_generic_filter_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),
+        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),  # noqa: E501
     ],
 )
 @pytest.mark.parametrize(
@@ -125,19 +126,19 @@ def test_generic_filter_comprehensions(da_func):
         (
             lambda x: (np.array(x) ** 2).sum(),
             None,
-            (np.mgrid[-2 : 2 + 1, -2 : 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
+            (np.mgrid[-2: 2 + 1, -2: 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
             0,
         ),
         (
             lambda x: (np.array(x) ** 2).sum(),
             None,
-            (np.mgrid[-2 : 2 + 1, -2 : 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
+            (np.mgrid[-2: 2 + 1, -2: 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
             (1, 2),
         ),
         (
             lambda x: (np.array(x) ** 2).sum(),
             None,
-            (np.mgrid[-2 : 2 + 1, -2 : 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
+            (np.mgrid[-2: 2 + 1, -2: 2 + 1] ** 2).sum(axis=0) < 2.5 ** 2,
             (-1, -2),
         ),
         (lambda x: (np.array(x) ** 2).sum(), 5, None, 0),
@@ -148,7 +149,8 @@ def test_generic_filter_comprehensions(da_func):
         (lambda x: (np.array(x) ** 2).sum(), 5, None, -2),
     ],
 )
-def test_generic_filter_compare(sp_func, da_func, function, size, footprint, origin):
+def test_generic_filter_compare(sp_func, da_func, function, size, footprint,
+                                origin):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -74,7 +74,7 @@ def test_generic_filter_shape_type(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.generic_filter, da_ndf.generic_filter),
+        (scipy.ndimage.filters.generic_filter, da_ndf.generic_filter),
     ]
 )
 @pytest.mark.parametrize(
@@ -127,7 +127,7 @@ def test_generic_filter_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (sp_ndf.generic_filter, da_ndf.generic_filter),
+        (scipy.ndimage.filters.generic_filter, da_ndf.generic_filter),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -4,9 +4,7 @@ import pytest
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
 
@@ -95,11 +93,11 @@ def test_generic_filter_identity(sp_func,
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         d, da_func(d, function, size=size, footprint=footprint)
     )
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, function, size=size, footprint=footprint),
         da_func(d, function, size=size, footprint=footprint),
     )
@@ -122,8 +120,8 @@ def test_generic_filter_comprehensions(da_func):
     l2s = [da_wfunc(d[i]) for i in range(len(d))]
     l2c = [da_wfunc(d[i])[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 @pytest.mark.parametrize(
@@ -224,7 +222,7 @@ def test_generic_filter_compare(sp_func,
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(
             a, function, size=size, footprint=footprint, origin=origin
         ),

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -6,17 +6,17 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 @pytest.mark.parametrize(
     "da_func, extra_kwargs",
     [
-        (da_ndf.minimum_filter, {}),
-        (da_ndf.median_filter, {}),
-        (da_ndf.maximum_filter, {}),
-        (da_ndf.rank_filter, {"rank": 0}),
-        (da_ndf.percentile_filter, {"percentile": 0}),
+        (dask_image.ndfilters.minimum_filter, {}),
+        (dask_image.ndfilters.median_filter, {}),
+        (dask_image.ndfilters.maximum_filter, {}),
+        (dask_image.ndfilters.rank_filter, {"rank": 0}),
+        (dask_image.ndfilters.percentile_filter, {"percentile": 0}),
     ]
 )
 @pytest.mark.parametrize(
@@ -58,11 +58,11 @@ def test_order_filter_params(da_func,
 @pytest.mark.parametrize(
     "da_func, extra_kwargs",
     [
-        (da_ndf.minimum_filter, {}),
-        (da_ndf.median_filter, {}),
-        (da_ndf.maximum_filter, {}),
-        (da_ndf.rank_filter, {"rank": 0}),
-        (da_ndf.percentile_filter, {"percentile": 0}),
+        (dask_image.ndfilters.minimum_filter, {}),
+        (dask_image.ndfilters.median_filter, {}),
+        (dask_image.ndfilters.maximum_filter, {}),
+        (dask_image.ndfilters.rank_filter, {"rank": 0}),
+        (dask_image.ndfilters.percentile_filter, {"percentile": 0}),
     ]
 )
 def test_ordered_filter_shape_type(da_func,
@@ -83,15 +83,15 @@ def test_ordered_filter_shape_type(da_func,
     "sp_func, da_func, extra_kwargs",
     [
         (scipy.ndimage.filters.minimum_filter,
-         da_ndf.minimum_filter, {}),
+         dask_image.ndfilters.minimum_filter, {}),
         (scipy.ndimage.filters.median_filter,
-         da_ndf.median_filter, {}),
+         dask_image.ndfilters.median_filter, {}),
         (scipy.ndimage.filters.maximum_filter,
-         da_ndf.maximum_filter, {}),
+         dask_image.ndfilters.maximum_filter, {}),
         (scipy.ndimage.filters.rank_filter,
-         da_ndf.rank_filter, {"rank": 0}),
+         dask_image.ndfilters.rank_filter, {"rank": 0}),
         (scipy.ndimage.filters.percentile_filter,
-         da_ndf.percentile_filter, {"percentile": 0}),
+         dask_image.ndfilters.percentile_filter, {"percentile": 0}),
     ]
 )
 @pytest.mark.parametrize(
@@ -123,11 +123,11 @@ def test_ordered_filter_identity(sp_func,
 @pytest.mark.parametrize(
     "da_func, kwargs",
     [
-        (da_ndf.minimum_filter, {"size": 1}),
-        (da_ndf.median_filter, {"size": 1}),
-        (da_ndf.maximum_filter, {"size": 1}),
-        (da_ndf.rank_filter, {"size": 1, "rank": 0}),
-        (da_ndf.percentile_filter, {"size": 1, "percentile": 0}),
+        (dask_image.ndfilters.minimum_filter, {"size": 1}),
+        (dask_image.ndfilters.median_filter, {"size": 1}),
+        (dask_image.ndfilters.maximum_filter, {"size": 1}),
+        (dask_image.ndfilters.rank_filter, {"size": 1, "rank": 0}),
+        (dask_image.ndfilters.percentile_filter, {"size": 1, "percentile": 0}),
     ]
 )
 def test_order_comprehensions(da_func, kwargs):
@@ -147,15 +147,15 @@ def test_order_comprehensions(da_func, kwargs):
     "sp_func, da_func, extra_kwargs",
     [
         (scipy.ndimage.filters.minimum_filter,
-         da_ndf.minimum_filter, {}),
+         dask_image.ndfilters.minimum_filter, {}),
         (scipy.ndimage.filters.median_filter,
-         da_ndf.median_filter, {}),
+         dask_image.ndfilters.median_filter, {}),
         (scipy.ndimage.filters.maximum_filter,
-         da_ndf.maximum_filter, {}),
+         dask_image.ndfilters.maximum_filter, {}),
         (scipy.ndimage.filters.rank_filter,
-         da_ndf.rank_filter, {"rank": 1}),
+         dask_image.ndfilters.rank_filter, {"rank": 1}),
         (scipy.ndimage.filters.percentile_filter,
-         da_ndf.percentile_filter, {"percentile": 10}),
+         dask_image.ndfilters.percentile_filter, {"percentile": 10}),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -82,15 +82,15 @@ def test_ordered_filter_shape_type(da_func,
 @pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
-        (sp_ndf.minimum_filter,
+        (scipy.ndimage.filters.minimum_filter,
          da_ndf.minimum_filter, {}),
-        (sp_ndf.median_filter,
+        (scipy.ndimage.filters.median_filter,
          da_ndf.median_filter, {}),
-        (sp_ndf.maximum_filter,
+        (scipy.ndimage.filters.maximum_filter,
          da_ndf.maximum_filter, {}),
-        (sp_ndf.rank_filter,
+        (scipy.ndimage.filters.rank_filter,
          da_ndf.rank_filter, {"rank": 0}),
-        (sp_ndf.percentile_filter,
+        (scipy.ndimage.filters.percentile_filter,
          da_ndf.percentile_filter, {"percentile": 0}),
     ]
 )
@@ -146,15 +146,15 @@ def test_order_comprehensions(da_func, kwargs):
 @pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
-        (sp_ndf.minimum_filter,
+        (scipy.ndimage.filters.minimum_filter,
          da_ndf.minimum_filter, {}),
-        (sp_ndf.median_filter,
+        (scipy.ndimage.filters.median_filter,
          da_ndf.median_filter, {}),
-        (sp_ndf.maximum_filter,
+        (scipy.ndimage.filters.maximum_filter,
          da_ndf.maximum_filter, {}),
-        (sp_ndf.rank_filter,
+        (scipy.ndimage.filters.rank_filter,
          da_ndf.rank_filter, {"rank": 1}),
-        (sp_ndf.percentile_filter,
+        (scipy.ndimage.filters.percentile_filter,
          da_ndf.percentile_filter, {"percentile": 10}),
     ]
 )

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -11,9 +11,6 @@ import dask.array.utils as dau
 import dask_image.ndfilters as da_ndf
 
 
-assert dask
-
-
 @pytest.mark.parametrize(
     "da_func, extra_kwargs",
     [

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -4,9 +4,7 @@ import pytest
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
 
@@ -112,11 +110,11 @@ def test_ordered_filter_identity(sp_func,
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         d, da_func(d, size=size, footprint=footprint, **extra_kwargs)
     )
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(a, size=size, footprint=footprint, **extra_kwargs),
         da_func(d, size=size, footprint=footprint, **extra_kwargs)
     )
@@ -141,8 +139,8 @@ def test_order_comprehensions(da_func, kwargs):
     l2s = [da_func(d[i], **kwargs) for i in range(len(d))]
     l2c = [da_func(d[i], **kwargs)[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 @pytest.mark.parametrize(
@@ -187,7 +185,7 @@ def test_ordered_filter_compare(sp_func,
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_func(
             a, size=size, footprint=footprint, origin=origin, **extra_kwargs
         ),

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
@@ -13,7 +9,6 @@ import dask.array as da
 import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
-
 
 assert dask
 

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -4,13 +4,9 @@ import pytest
 import numpy as np
 import scipy.ndimage.filters as sp_ndf
 
-import dask
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndfilters as da_ndf
-
-assert dask
 
 
 @pytest.mark.parametrize(
@@ -57,8 +53,8 @@ def test_uniform_comprehensions():
     l2s = [da_func(d[i]) for i in range(len(d))]
     l2c = [da_func(d[i])[None] for i in range(len(d))]
 
-    dau.assert_eq(np.stack(l2s), da.stack(l2s))
-    dau.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
+    da.utils.assert_eq(np.stack(l2s), da.stack(l2s))
+    da.utils.assert_eq(np.concatenate(l2c), da.concatenate(l2c))
 
 
 @pytest.mark.parametrize(
@@ -71,11 +67,11 @@ def test_uniform_identity(size, origin):
     a = np.arange(140.0).reshape(10, 14)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         d, da_ndf.uniform_filter(d, size, origin=origin)
     )
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_ndf.uniform_filter(a, size, origin=origin),
         da_ndf.uniform_filter(d, size, origin=origin)
     )
@@ -97,7 +93,7 @@ def test_uniform_compare(size, origin):
     a = np.arange(float(np.prod(s))).reshape(s)
     d = da.from_array(a, chunks=(50, 55))
 
-    dau.assert_eq(
+    da.utils.assert_eq(
         sp_ndf.uniform_filter(a, size, origin=origin),
         da_ndf.uniform_filter(d, size, origin=origin)
     )

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -43,7 +43,7 @@ def test_uniform_shape_type():
 
 
 def test_uniform_comprehensions():
-    da_func = lambda arr: dask_image.ndfilters.uniform_filter(arr, 1, origin=0)  # noqa: E731
+    da_func = lambda arr: dask_image.ndfilters.uniform_filter(arr, 1, origin=0)  # noqa: E731, E501
 
     np.random.seed(0)
 

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -6,7 +6,7 @@ import scipy.ndimage
 
 import dask.array as da
 
-import dask_image.ndfilters as da_ndf
+import dask_image.ndfilters
 
 
 @pytest.mark.parametrize(
@@ -25,7 +25,7 @@ def test_uniform_filter_params(err_type, size, origin):
     d = da.from_array(a, chunks=(5, 7))
 
     with pytest.raises(err_type):
-        da_ndf.uniform_filter(d, size, origin=origin)
+        dask_image.ndfilters.uniform_filter(d, size, origin=origin)
 
 
 def test_uniform_shape_type():
@@ -37,13 +37,13 @@ def test_uniform_shape_type():
 
     assert all([(type(s) is int) for s in d.shape])
 
-    d2 = da_ndf.uniform_filter(d, size, origin=origin)
+    d2 = dask_image.ndfilters.uniform_filter(d, size, origin=origin)
 
     assert all([(type(s) is int) for s in d2.shape])
 
 
 def test_uniform_comprehensions():
-    da_func = lambda arr: da_ndf.uniform_filter(arr, 1, origin=0)  # noqa: E731
+    da_func = lambda arr: dask_image.ndfilters.uniform_filter(arr, 1, origin=0)  # noqa: E731
 
     np.random.seed(0)
 
@@ -68,12 +68,12 @@ def test_uniform_identity(size, origin):
     d = da.from_array(a, chunks=(5, 7))
 
     da.utils.assert_eq(
-        d, da_ndf.uniform_filter(d, size, origin=origin)
+        d, dask_image.ndfilters.uniform_filter(d, size, origin=origin)
     )
 
     da.utils.assert_eq(
         scipy.ndimage.filters.uniform_filter(a, size, origin=origin),
-        da_ndf.uniform_filter(d, size, origin=origin)
+        dask_image.ndfilters.uniform_filter(d, size, origin=origin)
     )
 
 
@@ -95,5 +95,5 @@ def test_uniform_compare(size, origin):
 
     da.utils.assert_eq(
         scipy.ndimage.filters.uniform_filter(a, size, origin=origin),
-        da_ndf.uniform_filter(d, size, origin=origin)
+        dask_image.ndfilters.uniform_filter(d, size, origin=origin)
     )

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage.filters as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 
@@ -72,7 +72,7 @@ def test_uniform_identity(size, origin):
     )
 
     da.utils.assert_eq(
-        sp_ndf.uniform_filter(a, size, origin=origin),
+        scipy.ndimage.filters.uniform_filter(a, size, origin=origin),
         da_ndf.uniform_filter(d, size, origin=origin)
     )
 
@@ -94,6 +94,6 @@ def test_uniform_compare(size, origin):
     d = da.from_array(a, chunks=(50, 55))
 
     da.utils.assert_eq(
-        sp_ndf.uniform_filter(a, size, origin=origin),
+        scipy.ndimage.filters.uniform_filter(a, size, origin=origin),
         da_ndf.uniform_filter(d, size, origin=origin)
     )

--- a/tests/test_dask_image/test_ndfilters/test__utils.py
+++ b/tests/test_dask_image/test_ndfilters/test__utils.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import inspect
 
 import pytest
-
 import numpy
 
 from dask_image.ndfilters import _utils

--- a/tests/test_dask_image/test_ndfilters/test__utils.py
+++ b/tests/test_dask_image/test_ndfilters/test__utils.py
@@ -3,7 +3,7 @@
 import inspect
 
 import pytest
-import numpy
+import numpy as np
 
 from dask_image.ndfilters import _utils
 
@@ -118,9 +118,9 @@ def test_errs__get_origin(err_type, size, origin):
     "err_type, ndim, size, footprint",
     [
         (RuntimeError, 1, None, None),
-        (RuntimeError, 1, [2], numpy.ones((2,), dtype=bool)),
-        (RuntimeError, 1, None, numpy.ones((1, 2), dtype=bool)),
-        (RuntimeError, 1, None, numpy.ones([0], dtype=bool)),
+        (RuntimeError, 1, [2], np.ones((2,), dtype=bool)),
+        (RuntimeError, 1, None, np.ones((1, 2), dtype=bool)),
+        (RuntimeError, 1, None, np.ones([0], dtype=bool)),
     ]
 )
 def test_errs__get_footprint(err_type, ndim, size, footprint):
@@ -181,8 +181,8 @@ def test__get_depth(expected, size, origin):
 @pytest.mark.parametrize(
     "expected, ndim, size, footprint",
     [
-        (numpy.ones((2,), dtype=bool), 1, 2, None),
-        (numpy.ones((2,), dtype=bool), 1, None, numpy.ones((2,), dtype=bool)),
+        (np.ones((2,), dtype=bool), 1, 2, None),
+        (np.ones((2,), dtype=bool), 1, None, np.ones((2,), dtype=bool)),
     ]
 )
 def test__get_footprint(expected, ndim, size, footprint):

--- a/tests/test_dask_image/test_ndfilters/test_cupy_ndfilters.py
+++ b/tests/test_dask_image/test_ndfilters/test_cupy_ndfilters.py
@@ -5,7 +5,7 @@ import dask.array as da
 import numpy as np
 import pytest
 
-from dask_image import ndfilters
+import dask_image.ndfilters
 
 cupy = pytest.importorskip("cupy", minversion="7.7.0")
 
@@ -20,8 +20,8 @@ def array():
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func", [
-    ndfilters.convolve,
-    ndfilters.correlate,
+    dask_image.ndfilters.convolve,
+    dask_image.ndfilters.correlate,
 ])
 def test_cupy_conv(array, func):
     """Test convolve & correlate filters with cupy input arrays."""
@@ -32,7 +32,7 @@ def test_cupy_conv(array, func):
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func", [
-    ndfilters.laplace,
+    dask_image.ndfilters.laplace,
 ])
 def test_cupy_diff(array, func):
     result = func(array)
@@ -41,8 +41,8 @@ def test_cupy_diff(array, func):
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func", [
-    ndfilters.prewitt,
-    ndfilters.sobel,
+    dask_image.ndfilters.prewitt,
+    dask_image.ndfilters.sobel,
 ])
 def test_cupy_edge(array, func):
     result = func(array)
@@ -51,9 +51,9 @@ def test_cupy_edge(array, func):
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func", [
-    ndfilters.gaussian_filter,
-    ndfilters.gaussian_gradient_magnitude,
-    ndfilters.gaussian_laplace,
+    dask_image.ndfilters.gaussian_filter,
+    dask_image.ndfilters.gaussian_gradient_magnitude,
+    dask_image.ndfilters.gaussian_laplace,
 ])
 def test_cupy_gaussian(array, func):
     sigma = 1
@@ -72,18 +72,18 @@ def test_cupy_gaussian(array, func):
 def test_cupy_generic(array, size, footprint):
     my_sum = cupy.ReductionKernel(
         'T x', 'T out', 'x', 'a + b', 'out = a', '0', 'my_sum')
-    result = ndfilters.generic_filter(array, my_sum, size=size,
-                                      footprint=footprint)
+    result = dask_image.ndfilters.generic_filter(array, my_sum, size=size,
+                                                 footprint=footprint)
     result.compute()
 
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func, extra_arg, size", [
-    (ndfilters.minimum_filter, None, 3),
-    (ndfilters.median_filter, None, 3),
-    (ndfilters.maximum_filter, None, 3),
-    (ndfilters.rank_filter, 5, 3),
-    (ndfilters.percentile_filter, 50, 3),
+    (dask_image.ndfilters.minimum_filter, None, 3),
+    (dask_image.ndfilters.median_filter, None, 3),
+    (dask_image.ndfilters.maximum_filter, None, 3),
+    (dask_image.ndfilters.rank_filter, 5, 3),
+    (dask_image.ndfilters.percentile_filter, 50, 3),
 ])
 def test_cupy_order(array, func, extra_arg, size):
     if extra_arg is not None:
@@ -95,7 +95,7 @@ def test_cupy_order(array, func, extra_arg, size):
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func", [
-    ndfilters.uniform_filter,
+    dask_image.ndfilters.uniform_filter,
 ])
 def test_cupy_smooth(array, func):
     result = func(array)

--- a/tests/test_dask_image/test_ndfourier/test__utils.py
+++ b/tests/test_dask_image/test_ndfourier/test__utils.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-
 import numbers
 
 import pytest

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import numbers
 from distutils.version import LooseVersion
 
 import pytest
-
 import numpy as np
 import scipy as sp
 import scipy.ndimage.fourier as sp_ndf

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -9,7 +9,6 @@ import scipy as sp
 import scipy.ndimage.fourier as sp_ndf
 
 import dask.array as da
-import dask.array.utils as dau
 import dask_image.ndfourier as da_ndf
 
 
@@ -69,8 +68,8 @@ def test_fourier_filter_identity(funcname, s):
 
     assert d.chunks == r_d.chunks
 
-    dau.assert_eq(d, r_d)
-    dau.assert_eq(r_a, r_d)
+    da.utils.assert_eq(d, r_d)
+    da.utils.assert_eq(r_a, r_d)
 
 
 @pytest.mark.parametrize(
@@ -116,7 +115,7 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
 
     assert d.chunks == r_d.chunks
 
-    dau.assert_eq(r_a, r_d)
+    da.utils.assert_eq(r_a, r_d)
 
     if issubclass(dtype, upcast_type):
         assert r_d.real.dtype.type is np.float64
@@ -158,7 +157,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
 
     assert d.chunks == r_d.chunks
 
-    dau.assert_eq(r_a, r_d)
+    da.utils.assert_eq(r_a, r_d)
 
 
 @pytest.mark.parametrize(
@@ -191,7 +190,7 @@ def test_fourier_filter_non_positive(funcname, s):
 
     assert d.chunks == r_d.chunks
 
-    dau.assert_eq(r_a, r_d)
+    da.utils.assert_eq(r_a, r_d)
 
 
 @pytest.mark.parametrize(
@@ -226,4 +225,4 @@ def test_fourier_filter(funcname, s):
 
     assert d.chunks == r_d.chunks
 
-    dau.assert_eq(r_a, r_d)
+    da.utils.assert_eq(r_a, r_d)

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -6,7 +6,7 @@ from distutils.version import LooseVersion
 import pytest
 import numpy as np
 import scipy as sp
-import scipy.ndimage.fourier as sp_ndf
+import scipy.ndimage
 
 import dask.array as da
 import dask_image.ndfourier as da_ndf
@@ -58,7 +58,7 @@ def test_fourier_filter_err(funcname, err_type, s, n):
 )
 def test_fourier_filter_identity(funcname, s):
     da_func = getattr(da_ndf, funcname)
-    sp_func = getattr(sp_ndf, funcname)
+    sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
@@ -105,7 +105,7 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
     s = 1
 
     da_func = getattr(da_ndf, funcname)
-    sp_func = getattr(sp_ndf, funcname)
+    sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))
@@ -147,7 +147,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
     s = 1
 
     da_func = getattr(da_ndf, funcname)
-    sp_func = getattr(sp_ndf, funcname)
+    sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(np.prod(shape)).reshape(shape).astype(dtype)
     d = da.from_array(a, chunks=chunks)
@@ -180,7 +180,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
 )
 def test_fourier_filter_non_positive(funcname, s):
     da_func = getattr(da_ndf, funcname)
-    sp_func = getattr(sp_ndf, funcname)
+    sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
@@ -215,7 +215,7 @@ def test_fourier_filter_non_positive(funcname, s):
 )
 def test_fourier_filter(funcname, s):
     da_func = getattr(da_ndf, funcname)
-    sp_func = getattr(sp_ndf, funcname)
+    sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -213,11 +213,8 @@ def test_fourier_filter_non_positive(funcname, s):
         "fourier_uniform",
     ]
 )
-<<<<<<< HEAD
-def test_fourier_filter(funcname, s):
-    da_func = getattr(dask_image.ndfourier, funcname)
-    sp_func = getattr(scipy.ndimage.fourier, funcname)
-=======
+
+
 @pytest.mark.parametrize(
     "real_fft, axis",
     [
@@ -227,9 +224,8 @@ def test_fourier_filter(funcname, s):
     ]
 )
 def test_fourier_filter(funcname, s, real_fft, axis):
-    da_func = getattr(da_ndf, funcname)
-    sp_func = getattr(sp_ndf, funcname)
->>>>>>> main
+    da_func = getattr(dask_image.ndfourier, funcname)
+    sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     shape = (10, 14)
     n = 2 * shape[axis] - 1 if real_fft else -1

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -9,7 +9,7 @@ import scipy as sp
 import scipy.ndimage
 
 import dask.array as da
-import dask_image.ndfourier as da_ndf
+import dask_image.ndfourier
 
 
 @pytest.mark.parametrize(
@@ -33,7 +33,7 @@ import dask_image.ndfourier as da_ndf
     ]
 )
 def test_fourier_filter_err(funcname, err_type, s, n):
-    da_func = getattr(da_ndf, funcname)
+    da_func = getattr(dask_image.ndfourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
@@ -57,7 +57,7 @@ def test_fourier_filter_err(funcname, err_type, s, n):
     ]
 )
 def test_fourier_filter_identity(funcname, s):
-    da_func = getattr(da_ndf, funcname)
+    da_func = getattr(dask_image.ndfourier, funcname)
     sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
@@ -104,7 +104,7 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
 
     s = 1
 
-    da_func = getattr(da_ndf, funcname)
+    da_func = getattr(dask_image.ndfourier, funcname)
     sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(dtype)
@@ -146,7 +146,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
 
     s = 1
 
-    da_func = getattr(da_ndf, funcname)
+    da_func = getattr(dask_image.ndfourier, funcname)
     sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(np.prod(shape)).reshape(shape).astype(dtype)
@@ -179,7 +179,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
     ]
 )
 def test_fourier_filter_non_positive(funcname, s):
-    da_func = getattr(da_ndf, funcname)
+    da_func = getattr(dask_image.ndfourier, funcname)
     sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
@@ -214,7 +214,7 @@ def test_fourier_filter_non_positive(funcname, s):
     ]
 )
 def test_fourier_filter(funcname, s):
-    da_func = getattr(da_ndf, funcname)
+    da_func = getattr(dask_image.ndfourier, funcname)
     sp_func = getattr(scipy.ndimage.fourier, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -216,7 +216,7 @@ def test_affine_transform_prefilter_warning():
 
     with pytest.warns(UserWarning):
         dask_image.ndinterp.affine_transform(da.ones(3), [1], [0],
-                                     order=3, prefilter=True)
+                                             order=3, prefilter=True)
 
 
 @pytest.mark.timeout(15)

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -74,7 +74,7 @@ def validate_affine_transform(n=2,
         and version.parse(dask.__version__) < version.parse("2020.1.0")
     ):
         # older dask will fail if any chunks have size smaller than depth
-        depth = da_ndinterp._get_default_depth(interp_order)
+        depth = dask_image.ndinterp._get_default_depth(interp_order)
         in_size = input_output_shape_per_dim[0]
         in_chunksize = input_output_chunksize_per_dim[0]
         rem = in_size % in_chunksize

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 import pytest
 
 import dask_image.ndinterp as da_ndinterp

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -287,7 +287,7 @@ def test_affine_transform_no_output_shape_or_chunks_specified():
 def test_affine_transform_prefilter_warning():
 
     with pytest.warns(UserWarning):
-        dask_image.ndinterp.affine_transform(da.ones(3), [1], [0],
+        dask_image.ndinterp.affine_transform(da.ones(20), [1], [0],
                                              order=3, prefilter=True)
 
 

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -10,7 +10,7 @@ import pytest
 import scipy
 import scipy.ndimage
 
-import dask_image.ndinterp as da_ndinterp
+import dask_image.ndinterp
 
 # mode lists for the case with prefilter = False
 _supported_modes = ['constant', 'nearest', 'reflect', 'mirror']
@@ -50,7 +50,7 @@ def validate_spline_filter(n=2,
 
     if version.parse(dask.__version__) < version.parse("2020.1.0"):
         # older dask will fail if any chunks have size smaller than depth
-        _depth = da_ndinterp._get_default_depth(interp_order)
+        _depth = dask_image.ndinterp._get_default_depth(interp_order)
         rem = axis_size % chunksize
         if chunksize < _depth or (rem != 0 and rem < _depth):
             pytest.skip("older dask doesn't automatically rechunk")
@@ -70,11 +70,11 @@ def validate_spline_filter(n=2,
 
     if axis is not None:
         scipy_func = scipy.ndimage.spline_filter1d
-        dask_image_func = da_ndinterp.spline_filter1d
+        dask_image_func = dask_image.ndinterp.spline_filter1d
         kwargs = {'axis': axis}
     else:
         scipy_func = scipy.ndimage.spline_filter
-        dask_image_func = da_ndinterp.spline_filter
+        dask_image_func = dask_image.ndinterp.spline_filter
         kwargs = {}
 
     # transform with scipy

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
-
 import dask.array as da
 import dask.array.utils as dau
 

--- a/tests/test_dask_image/test_ndmeasure/test__utils.py
+++ b/tests/test_dask_image/test_ndmeasure/test__utils.py
@@ -3,7 +3,6 @@
 import pytest
 import numpy as np
 import dask.array as da
-import dask.array.utils as dau
 
 import dask_image.ndmeasure._utils
 
@@ -49,9 +48,9 @@ def test__norm_input_labels_index():
     assert d_lbls_n.shape == d_lbls.shape
     assert ind_n.shape == ()
 
-    dau.assert_eq(d_n, d)
-    dau.assert_eq(d_lbls_n, d_lbls)
-    dau.assert_eq(ind_n, np.array(1, dtype=int))
+    da.utils.assert_eq(d_n, d)
+    da.utils.assert_eq(d_lbls_n, d_lbls)
+    da.utils.assert_eq(ind_n, np.array(1, dtype=int))
 
 
 @pytest.mark.parametrize(
@@ -105,4 +104,4 @@ def test___ravel_shape_indices(shape, chunks):
         shape, dtype=np.int64, chunks=chunks
     )
 
-    dau.assert_eq(d, a)
+    da.utils.assert_eq(d, a)

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -114,7 +114,7 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     else:
         scipy_funcname = funcname
 
-    sp_func = getattr(ndi, scipy_funcname)
+    sp_func = getattr(scipy.ndimage, scipy_funcname)
     da_func = getattr(dask_image.ndmeasure, funcname)
 
     a = np.random.random(shape)

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from distutils.version import LooseVersion
-import scipy
 import itertools as it
 import warnings as wrn
 

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -8,7 +8,7 @@ import warnings as wrn
 import pytest
 import numpy as np
 import scipy
-import scipy.ndimage as spnd
+import scipy.ndimage
 
 import dask.array as da
 
@@ -114,7 +114,7 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     else:
         scipy_funcname = funcname
 
-    sp_func = getattr(spnd, scipy_funcname)
+    sp_func = getattr(ndi, scipy_funcname)
     da_func = getattr(dask_image.ndmeasure, funcname)
 
     a = np.random.random(shape)
@@ -243,7 +243,7 @@ def test_extrema(shape, chunks, has_lbls, ind):
         )
         d_lbls = da.from_array(lbls, chunks=d.chunks)
 
-    a_r = spnd.extrema(a, lbls, ind)
+    a_r = scipy.ndimage.extrema(a, lbls, ind)
     d_r = dask_image.ndmeasure.extrema(d, d_lbls, ind)
 
     assert len(a_r) == len(d_r)
@@ -298,7 +298,7 @@ def test_histogram(shape, chunks, has_lbls, ind, min, max, bins):
         )
         d_lbls = da.from_array(lbls, chunks=d.chunks)
 
-    a_r = spnd.histogram(a, min, max, bins, lbls, ind)
+    a_r = scipy.ndimage.histogram(a, min, max, bins, lbls, ind)
     d_r = dask_image.ndmeasure.histogram(d, min, max, bins, d_lbls, ind)
 
     if ind is None or np.isscalar(ind):
@@ -351,9 +351,9 @@ def test_label(seed, prob, shape, chunks, connectivity):
     a = np.random.random(shape) < prob
     d = da.from_array(a, chunks=chunks)
 
-    s = spnd.generate_binary_structure(a.ndim, connectivity)
+    s = scipy.ndimage.generate_binary_structure(a.ndim, connectivity)
 
-    a_l, a_nl = spnd.label(a, s)
+    a_l, a_nl = scipy.ndimage.label(a, s)
     d_l, d_nl = dask_image.ndmeasure.label(d, s)
 
     assert a_nl == d_nl.compute()
@@ -408,7 +408,7 @@ def test_labeled_comprehension(shape, chunks, ind, default, pass_positions):
 
         return (val * pos).sum() / (1 + val.max() * pos.max())
 
-    a_cm = spnd.labeled_comprehension(
+    a_cm = scipy.ndimage.labeled_comprehension(
         a, lbls, ind, func, np.float64, default, pass_positions
     )
     d_cm = dask_image.ndmeasure.labeled_comprehension(
@@ -465,10 +465,10 @@ def test_labeled_comprehension_struct(shape, chunks, ind):
 
         return result[()]
 
-    a_max = spnd.labeled_comprehension(
+    a_max = scipy.ndimage.labeled_comprehension(
         a, lbls, ind, func_max, dtype["val"], default["val"], False
     )
-    a_argmax = spnd.labeled_comprehension(
+    a_argmax = scipy.ndimage.labeled_comprehension(
         a, lbls, ind, func_argmax, dtype["pos"], default["pos"], True
     )
 
@@ -519,7 +519,7 @@ def test_labeled_comprehension_object(shape, chunks, ind):
     def func_min_max(val):
         return np.array([np.min(val), np.max(val)])
 
-    a_r = spnd.labeled_comprehension(
+    a_r = scipy.ndimage.labeled_comprehension(
         a, lbls, ind, func_min_max, dtype, default, False
     )
 

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -1,16 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
 from distutils.version import LooseVersion
 import scipy
 import itertools as it
 import warnings as wrn
 
 import pytest
-
 import numpy as np
-
 import scipy
 import scipy.ndimage as spnd
 

--- a/tests/test_dask_image/test_ndmorph/test__utils.py
+++ b/tests/test_dask_image/test_ndmorph/test__utils.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import dask.array
+import dask.array as da
 
 from dask_image.ndmorph import _utils
 
@@ -12,12 +12,12 @@ from dask_image.ndmorph import _utils
     [
         (
             RuntimeError,
-            dask.array.ones([1, 2], dtype=bool, chunks=(1, 2,)),
-            dask.array.arange(2, dtype=bool, chunks=(2,))
+            da.ones([1, 2], dtype=bool, chunks=(1, 2,)),
+            da.arange(2, dtype=bool, chunks=(2,))
         ),
         (
             TypeError,
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
             2.0
         ),
     ]
@@ -44,12 +44,12 @@ def test_errs__get_iterations(err_type, iterations):
     [
         (
             RuntimeError,
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
-            dask.array.arange(1, dtype=bool, chunks=(2,))
+            da.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(1, dtype=bool, chunks=(2,))
         ),
         (
             TypeError,
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
             2.0
         ),
     ]
@@ -88,22 +88,22 @@ def test_errs__get_brute_force(err_type, brute_force):
     [
         (
             np.array([1, 1, 1], dtype=bool),
-            (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
+            (da.arange(10, chunks=(10,)) % 2).astype(bool),
             None
         ),
         (
             np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool),
-            (dask.array.arange(100, chunks=10).reshape(10, 10) % 2).astype(bool),  # noqa: E501
+            (da.arange(100, chunks=10).reshape(10, 10) % 2).astype(bool),  # noqa: E501
             None
         ),
         (
             np.array([1, 1, 1], dtype=bool),
-            (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
+            (da.arange(10, chunks=(10,)) % 2).astype(bool),
             np.array([1, 1, 1], dtype=int)
         ),
         (
             np.array([1, 1, 1], dtype=bool),
-            (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
+            (da.arange(10, chunks=(10,)) % 2).astype(bool),
             np.array([1, 1, 1], dtype=bool)
         ),
     ]
@@ -144,28 +144,28 @@ def test__get_dtype(expected, a):
 @pytest.mark.parametrize(
     "expected, input, mask",
     [
-        (True, dask.array.arange(2, dtype=bool, chunks=(2,)), None),
-        (True, dask.array.arange(2, dtype=bool, chunks=(2,)), True),
-        (False, dask.array.arange(2, dtype=bool, chunks=(2,)), False),
+        (True, da.arange(2, dtype=bool, chunks=(2,)), None),
+        (True, da.arange(2, dtype=bool, chunks=(2,)), True),
+        (False, da.arange(2, dtype=bool, chunks=(2,)), False),
         (
             True,
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
             np.bool8(True)
         ),
         (
             False,
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
             np.bool8(False)
         ),
         (
             np.arange(2, dtype=bool),
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
             np.arange(2, dtype=bool)
         ),
         (
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
-            dask.array.arange(2, dtype=bool, chunks=(2,)),
-            dask.array.arange(2, dtype=int, chunks=(2,))
+            da.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=int, chunks=(2,))
         ),
     ]
 )
@@ -174,7 +174,7 @@ def test__get_mask(expected, input, mask):
 
     assert type(expected) == type(result)
 
-    if isinstance(expected, (np.ndarray, dask.array.Array)):
+    if isinstance(expected, (np.ndarray, da.Array)):
         assert np.array((expected == result).all())[()]
     else:
         assert expected == result

--- a/tests/test_dask_image/test_ndmorph/test__utils.py
+++ b/tests/test_dask_image/test_ndmorph/test__utils.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy
 import dask.array
 

--- a/tests/test_dask_image/test_ndmorph/test__utils.py
+++ b/tests/test_dask_image/test_ndmorph/test__utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
-import numpy
+import numpy as np
 import dask.array
 
 from dask_image.ndmorph import _utils
@@ -87,24 +87,24 @@ def test_errs__get_brute_force(err_type, brute_force):
     "expected, input, structure",
     [
         (
-            numpy.array([1, 1, 1], dtype=bool),
+            np.array([1, 1, 1], dtype=bool),
             (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
             None
         ),
         (
-            numpy.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool),
+            np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool),
             (dask.array.arange(100, chunks=10).reshape(10, 10) % 2).astype(bool),  # noqa: E501
             None
         ),
         (
-            numpy.array([1, 1, 1], dtype=bool),
+            np.array([1, 1, 1], dtype=bool),
             (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
-            numpy.array([1, 1, 1], dtype=int)
+            np.array([1, 1, 1], dtype=int)
         ),
         (
-            numpy.array([1, 1, 1], dtype=bool),
+            np.array([1, 1, 1], dtype=bool),
             (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
-            numpy.array([1, 1, 1], dtype=bool)
+            np.array([1, 1, 1], dtype=bool)
         ),
     ]
 )
@@ -112,7 +112,7 @@ def test__get_structure(expected, input, structure):
     result = _utils._get_structure(input, structure)
 
     assert expected.dtype.type == result.dtype.type
-    assert numpy.array((expected == result).all())[()]
+    assert np.array((expected == result).all())[()]
 
 
 @pytest.mark.parametrize(
@@ -129,12 +129,12 @@ def test__get_iterations(expected, iterations):
 @pytest.mark.parametrize(
     "expected, a",
     [
-        (numpy.bool8, False),
-        (numpy.int_, 2),
-        (numpy.float64, 3.1),
-        (numpy.complex128, 1 + 2j),
-        (numpy.int16, numpy.int16(6)),
-        (numpy.uint32, numpy.arange(3, dtype=numpy.uint32)),
+        (np.bool8, False),
+        (np.int_, 2),
+        (np.float64, 3.1),
+        (np.complex128, 1 + 2j),
+        (np.int16, np.int16(6)),
+        (np.uint32, np.arange(3, dtype=np.uint32)),
     ]
 )
 def test__get_dtype(expected, a):
@@ -150,17 +150,17 @@ def test__get_dtype(expected, a):
         (
             True,
             dask.array.arange(2, dtype=bool, chunks=(2,)),
-            numpy.bool8(True)
+            np.bool8(True)
         ),
         (
             False,
             dask.array.arange(2, dtype=bool, chunks=(2,)),
-            numpy.bool8(False)
+            np.bool8(False)
         ),
         (
-            numpy.arange(2, dtype=bool),
+            np.arange(2, dtype=bool),
             dask.array.arange(2, dtype=bool, chunks=(2,)),
-            numpy.arange(2, dtype=bool)
+            np.arange(2, dtype=bool)
         ),
         (
             dask.array.arange(2, dtype=bool, chunks=(2,)),
@@ -174,8 +174,8 @@ def test__get_mask(expected, input, mask):
 
     assert type(expected) == type(result)
 
-    if isinstance(expected, (numpy.ndarray, dask.array.Array)):
-        assert numpy.array((expected == result).all())[()]
+    if isinstance(expected, (np.ndarray, dask.array.Array)):
+        assert np.array((expected == result).all())[()]
     else:
         assert expected == result
 

--- a/tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py
@@ -5,7 +5,7 @@ import dask.array as da
 import numpy as np
 import pytest
 
-from dask_image import ndmorph
+import dask_image.ndmorph
 
 cupy = pytest.importorskip("cupy", minversion="7.7.0")
 
@@ -20,10 +20,10 @@ def array():
 
 @pytest.mark.cupy
 @pytest.mark.parametrize("func", [
-    ndmorph.binary_closing,
-    ndmorph.binary_dilation,
-    ndmorph.binary_erosion,
-    ndmorph.binary_opening,
+    dask_image.ndmorph.binary_closing,
+    dask_image.ndmorph.binary_dilation,
+    dask_image.ndmorph.binary_erosion,
+    dask_image.ndmorph.binary_opening,
 ])
 def test_cupy_ndmorph(array, func):
     """Test convolve & correlate filters with cupy input arrays."""

--- a/tests/test_dask_image/test_ndmorph/test_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_ndmorph.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import numpy as np
-import scipy.ndimage as spnd
+import scipy.ndimage
 
 import dask.array as da
 import dask_image.ndmorph as da_ndm
@@ -267,7 +267,7 @@ def test_binary_ops(funcname,
                     structure,
                     origin):
     da_func = getattr(da_ndm, funcname)
-    sp_func = getattr(spnd, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     da_result = da_func(
         input,
@@ -346,7 +346,7 @@ def test_binary_ops_iter(funcname,
                          iterations,
                          origin):
     da_func = getattr(da_ndm, funcname)
-    sp_func = getattr(spnd, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     da_result = da_func(
         input,
@@ -490,7 +490,7 @@ def test_binary_ops_expanded(funcname,
                              origin,
                              brute_force):
     da_func = getattr(da_ndm, funcname)
-    sp_func = getattr(spnd, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     da_result = da_func(
         input,

--- a/tests/test_dask_image/test_ndmorph/test_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_ndmorph.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.ndimage
 
 import dask.array as da
-import dask_image.ndmorph as da_ndm
+import dask_image.ndmorph
 
 
 @pytest.mark.parametrize(
@@ -45,7 +45,7 @@ def test_errs_binary_ops(funcname,
                          input,
                          structure,
                          origin):
-    da_func = getattr(da_ndm, funcname)
+    da_func = getattr(dask_image.ndmorph, funcname)
 
     with pytest.raises(err_type):
         da_func(
@@ -89,7 +89,7 @@ def test_errs_binary_ops_iter(funcname,
                               structure,
                               iterations,
                               origin):
-    da_func = getattr(da_ndm, funcname)
+    da_func = getattr(dask_image.ndmorph, funcname)
 
     with pytest.raises(err_type):
         da_func(
@@ -154,7 +154,7 @@ def test_errs_binary_ops_expanded(funcname,
                                   border_value,
                                   origin,
                                   brute_force):
-    da_func = getattr(da_ndm, funcname)
+    da_func = getattr(dask_image.ndmorph, funcname)
 
     with pytest.raises(err_type):
         da_func(
@@ -266,7 +266,7 @@ def test_binary_ops(funcname,
                     input,
                     structure,
                     origin):
-    da_func = getattr(da_ndm, funcname)
+    da_func = getattr(dask_image.ndmorph, funcname)
     sp_func = getattr(scipy.ndimage, funcname)
 
     da_result = da_func(
@@ -345,7 +345,7 @@ def test_binary_ops_iter(funcname,
                          structure,
                          iterations,
                          origin):
-    da_func = getattr(da_ndm, funcname)
+    da_func = getattr(dask_image.ndmorph, funcname)
     sp_func = getattr(scipy.ndimage, funcname)
 
     da_result = da_func(
@@ -489,7 +489,7 @@ def test_binary_ops_expanded(funcname,
                              border_value,
                              origin,
                              brute_force):
-    da_func = getattr(da_ndm, funcname)
+    da_func = getattr(dask_image.ndmorph, funcname)
     sp_func = getattr(scipy.ndimage, funcname)
 
     da_result = da_func(

--- a/tests/test_dask_image/test_ndmorph/test_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_ndmorph.py
@@ -5,7 +5,6 @@ import numpy as np
 import scipy.ndimage as spnd
 
 import dask.array as da
-import dask.array.utils as dau
 import dask_image.ndmorph as da_ndm
 
 
@@ -282,7 +281,7 @@ def test_binary_ops(funcname,
         origin=origin
     )
 
-    dau.assert_eq(sp_result, da_result)
+    da.utils.assert_eq(sp_result, da_result)
 
 
 @pytest.mark.parametrize(
@@ -363,7 +362,7 @@ def test_binary_ops_iter(funcname,
         origin=origin
     )
 
-    dau.assert_eq(sp_result, da_result)
+    da.utils.assert_eq(sp_result, da_result)
 
 
 @pytest.mark.parametrize(
@@ -513,4 +512,4 @@ def test_binary_ops_expanded(funcname,
         brute_force=brute_force
     )
 
-    dau.assert_eq(sp_result, da_result)
+    da.utils.assert_eq(sp_result, da_result)

--- a/tests/test_dask_image/test_ndmorph/test_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_ndmorph.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import pytest
-
 import numpy as np
 import scipy.ndimage as spnd
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -276,7 +276,6 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
 try:
     import configparser
 except ImportError:


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/226
Also addresses most of the points in https://github.com/dask/dask-image/issues/101 (except for moving the function definitions out of the `__init__.py` files)

In this PR, I have:

* Removed any `from __future__` imports
* Ran `isort` on all the files in the repository
* Removed the `assert dask` statements from the top of several test modules. (I believe they are superfluous, because if dask is not available there will be an `ImportError` while pytest is collecting tests, so I don't think we'll ever reach that line anyway? If I'm wrong and they're in for a reason, let me know and I'll reverse this change)
* Code style cleanup: Always use `import numpy as np`
* Code style cleanup: Always use `import dask.array as da`
* Code style cleanup: Always use `import scipy.ndimage`
* Code style cleanup: For clarity, use `import dask_image.ndfilters` instead of `import dask_image.ndfilters as da_ndf`
* Code style cleanup: flake8 formatting