### PR TITLE
Implement support for ndimage.map_coordinates

### DIFF
--- a/docs/coverage.rst
+++ b/docs/coverage.rst
@@ -145,7 +145,7 @@ This table shows which SciPy ndimage functions are supported by dask-image.
      - ✓
    * - ``map_coordinates``
      - ✓
-     -
+     - ✓
    * - ``maximum``
      - ✓
      - ✓

--- a/tests/test_dask_image/test_ndinterp/test_map_coordinates.py
+++ b/tests/test_dask_image/test_ndinterp/test_map_coordinates.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from packaging import version
+
+import dask.array as da
+import numpy as np
+import pytest
+import scipy
+import scipy.ndimage
+
+import dask_image.ndinterp
+
+# mode lists for the case with prefilter = False
+_supported_modes = ['constant', 'nearest']
+_unsupported_modes = ['wrap', 'reflect', 'mirror']
+
+# mode lists for the case with prefilter = True
+_supported_prefilter_modes = ['constant']
+_unsupported_prefilter_modes = _unsupported_modes + ['nearest']
+
+have_scipy16 = version.parse(scipy.__version__) >= version.parse('1.6.0')
+
+# additional modes are present in SciPy >= 1.6.0
+if have_scipy16:
+    _supported_modes += ['grid-constant']
+    _unsupported_modes += ['grid-mirror', 'grid-wrap']
+    _unsupported_prefilter_modes += ['grid-constant', 'grid-mirror',
+                                     'grid-wrap']
+
+
+def validate_map_coordinates_general(n=2,
+                                     interp_order=1,
+                                     interp_mode='constant',
+                                     coord_len=12,
+                                     coord_chunksize=6,
+                                     coord_offset=0.,
+                                     im_shape_per_dim=12,
+                                     im_chunksize_per_dim=6,
+                                     random_seed=0,
+                                     prefilter=False,
+                                     ):
+
+    if interp_order > 1 and interp_mode == 'nearest' and not have_scipy16:
+        # not clear on the underlying cause, but this fails on older SciPy
+        pytest.skip("requires SciPy >= 1.6.0")
+
+    # define test image
+    np.random.seed(random_seed)
+    image = np.random.random([im_shape_per_dim] * n)
+    image_da = da.from_array(image, chunks=im_chunksize_per_dim)
+
+    # define test coordinates
+    coords = np.random.random((n, coord_len)) * im_shape_per_dim + coord_offset
+
+    # ndimage result
+    ints_scipy = scipy.ndimage.map_coordinates(
+        image,
+        coords,
+        output=None,
+        order=interp_order,
+        mode=interp_mode,
+        cval=0.0,
+        prefilter=prefilter)
+
+    # dask-image result
+    ints_dask = dask_image.ndinterp.map_coordinates(
+        image_da,
+        coords,
+        order=interp_order,
+        mode=interp_mode,
+        cval=0.0,
+        prefilter=prefilter)
+
+    ints_dask_computed = ints_dask.compute()
+
+    assert np.allclose(ints_scipy, ints_dask_computed)
+
+
+@pytest.mark.parametrize("n",
+                         [1, 2, 3, 4])
+@pytest.mark.parametrize("random_seed",
+                         range(2))
+def test_map_coordinates_basic(n,
+                               random_seed,
+                               ):
+
+    kwargs = dict()
+    kwargs['n'] = n
+    kwargs['random_seed'] = random_seed
+
+    validate_map_coordinates_general(**kwargs)
+
+
+@pytest.mark.timeout(3)
+def test_map_coordinates_large_input():
+
+    # define large test image
+    image_da = da.random.random([1000] * 3, chunks=200)
+
+    # define sparse test coordinates
+    coords = np.random.random((3, 2)) * 1000
+
+    # dask-image result
+    dask_image.ndinterp.map_coordinates(
+        image_da,
+        coords).compute()


### PR DESCRIPTION
This PR suggests a `dask-image` implementation for `ndimage.map_coordinates` which covers the case in which the provided coordinates fit into memory and the `input` array consists of a (potentially large) dask array. See https://github.com/dask/dask-image/issues/235.

Implementation details:
- for every coordinate the corresponding chunk of the input array and the required input slice are determined
- coordinates are grouped based on associated chunks
- a task is defined for each group and minimum required input array slice to apply `ndimage.map_coordinates`
- output intensities are rearranged to match input order

Some tests are included, plan is for some more to be added following feedback on the choices of the implementation.