### PR TITLE
Upgrade for compatibility with latest dask release

### DIFF
--- a/dask_image/ndmeasure/_utils/__init__.py
+++ b/dask_image/ndmeasure/_utils/__init__.py
@@ -22,10 +22,10 @@ def _norm_input_labels_index(image, label_image=None, index=None):
         label_image = da.ones(
             image.shape, dtype=int, chunks=image.chunks,
         )
-        index = da.ones(tuple(), dtype=int, chunks=tuple())
+        index = da.from_array(np.array(1, dtype=int))
     elif index is None:
         label_image = (label_image > 0).astype(int)
-        index = da.ones(tuple(), dtype=int, chunks=tuple())
+        index = da.from_array(np.array(1, dtype=int))
 
     label_image = da.asarray(label_image)
     index = da.asarray(index)


### PR DESCRIPTION
The small update in this PR means our tests will pass with both old and newer dask versions.

The version of dask we have pinned in the test environments is quite old (as in, before the calver standard was adopted for dask releases). I want to depend on a more up-to-date version of dask (eg: for https://github.com/dask/dask-image/pull/240). 