### PR TITLE
Fix wrap bug in ndfilters convolve and correlate

### DIFF
--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -47,7 +47,7 @@ def correlate(image, weights, mode="reflect", cval=0.0, origin=0):
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
 
-    if mode == "wrap":
+    if mode == "wrap":  # Fixes https://github.com/dask/dask-image/issues/242
         boundary = "periodic"
         mode = "constant"
 

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -20,7 +20,7 @@ def convolve(image, weights, mode="reflect", cval=0.0, origin=0):
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
 
-    if mode == "wrap":
+    if mode == "wrap":  # Fixes https://github.com/dask/dask-image/issues/242
         boundary = "periodic"
         mode = "constant"
 

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -13,16 +13,16 @@ __all__ = [
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.convolve)
-def convolve(image,
-             weights,
-             mode='reflect',
-             cval=0.0,
-             origin=0):
+def convolve(image, weights, mode="reflect", cval=0.0, origin=0):
     check_arraytypes_compatible(image, weights)
 
     origin = _utils._get_origin(weights.shape, origin)
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
+
+    if mode == "wrap":
+        boundary = "periodic"
+        mode = "constant"
 
     result = image.map_overlap(
         dispatch_convolve(image),
@@ -33,23 +33,23 @@ def convolve(image,
         weights=weights,
         mode=mode,
         cval=cval,
-        origin=origin
+        origin=origin,
     )
 
     return result
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.correlate)
-def correlate(image,
-              weights,
-              mode='reflect',
-              cval=0.0,
-              origin=0):
+def correlate(image, weights, mode="reflect", cval=0.0, origin=0):
     check_arraytypes_compatible(image, weights)
 
     origin = _utils._get_origin(weights.shape, origin)
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
+
+    if mode == "wrap":
+        boundary = "periodic"
+        mode = "constant"
 
     result = image.map_overlap(
         dispatch_correlate(image),
@@ -60,7 +60,7 @@ def correlate(image,
         weights=weights,
         mode=mode,
         cval=cval,
-        origin=origin
+        origin=origin,
     )
 
     return result

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -154,3 +154,35 @@ def test_convolutions_compare(sp_func,
             d, weights, origin=origin
         )
     )
+@pytest.mark.parametrize(
+    "sp_func, da_func",
+    [
+        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
+    ]
+)
+@pytest.mark.parametrize(
+    "weights",
+    [
+     np.ones((1,5))
+     np.ones((5,1))
+    ]
+)
+@pytest.mark.parametrize(
+    "mode",
+    ["reflect","wrap","nearest","constant","mirror"])
+def test_convolutions_modes(sp_func,
+                            da_func,
+                            weights,
+                            mode):
+    a = np.arange(140).reshape(10,14)
+    d = da.from_array(a,chunks =(5, 7))
+    
+    da.utils.assert_eq(
+        sp_func(
+            a, weights, mode = mode
+        ),
+        da_func(
+            d, weights, mode = mode
+        )
+    )

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -164,8 +164,8 @@ def test_convolutions_compare(sp_func,
 @pytest.mark.parametrize(
     "weights",
     [
-     np.ones((1,5))
-     np.ones((5,1))
+     np.ones((1,5)),
+     np.ones((5,1)),
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes [#242]
This bugged was caused by letting Scipy handle the boundary conditions which cannot work when `mode = "wrap"` and the array has more than one chunk. 
Quick explanation of what happened : 
The old function does 
```python
   # mode is untouched from the call to ndfilters.convolve, boundary == "none" and everything else is irrelevant
    result = image.map_overlap(
        dispatch_convolve(image),
        depth=depth,
        boundary=boundary,
        dtype=image.dtype,
        meta=image._meta,
        weights=weights,
        mode=mode,
        cval=cval,
        origin=origin,
    )
```
This means that we will apply `scipy.ndimage.convolve` to each chunk. When `mode == "wrap"`, the wrapping will be done on the chunks which means that the values used for the boundaries are the edge values of the chunk and not the array, hence why it doesn't work properly. This is the only mode for which it happens because wrapping is the only case where being limited to a chunk is a problem. 

The fix I used is just those three lines. 
```python
    if mode == "wrap":
        boundary = "periodic"
        mode = "constant"
```

This also applies to `ndfilters.correlate`.