### PR TITLE
Convolution based on scipy.signal's function

### DIFF
--- a/continuous_integration/environment-3.6.yml
+++ b/continuous_integration/environment-3.6.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-flake8==1.0.4
   - dask==2.8.1
   - numpy==1.15.4
-  - scipy==1.2.0
+  - scipy==1.4.0
   - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-flake8==1.0.4
   - dask==2.8.1
   - numpy==1.15.4
-  - scipy==1.2.0
+  - scipy==1.4.0
   - scikit-image==0.14.2
   - pims==0.4.1
   - slicerator

--- a/continuous_integration/environment-3.8-dev.yml
+++ b/continuous_integration/environment-3.8-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-flake8==1.0.4
   - dask==2.8.1
   - numpy==1.17.3
-  - scipy==1.3.2
+  - scipy==1.4.0
   - scikit-image==0.16.2
   - pims==0.4.1
   - slicerator

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-flake8==1.0.4
   - dask==2.8.1
   - numpy==1.17.3
-  - scipy==1.3.2
+  - scipy==1.4.0
   - scikit-image==0.16.2
   - pims==0.4.1
   - slicerator

--- a/continuous_integration/environment-latest.yml
+++ b/continuous_integration/environment-latest.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-flake8==1.0.4
   - dask==2.8.1
   - numpy==1.17.3
-  - scipy==1.3.2
+  - scipy==1.4.0
   - scikit-image==0.16.2
   - pims==0.4.1
   - slicerator

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -13,16 +13,16 @@ __all__ = [
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.convolve)
-def convolve(image,
-             weights,
-             mode='reflect',
-             cval=0.0,
-             origin=0):
+def convolve(image, weights, mode="reflect", cval=0.0, origin=0):
     check_arraytypes_compatible(image, weights)
 
     origin = _utils._get_origin(weights.shape, origin)
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
+
+    if mode == "wrap":
+        boundary = "periodic"
+        mode = "constant"
 
     result = image.map_overlap(
         dispatch_convolve(image),
@@ -33,23 +33,23 @@ def convolve(image,
         weights=weights,
         mode=mode,
         cval=cval,
-        origin=origin
+        origin=origin,
     )
 
     return result
 
 
 @_utils._update_wrapper(scipy.ndimage.filters.correlate)
-def correlate(image,
-              weights,
-              mode='reflect',
-              cval=0.0,
-              origin=0):
+def correlate(image, weights, mode="reflect", cval=0.0, origin=0):
     check_arraytypes_compatible(image, weights)
 
     origin = _utils._get_origin(weights.shape, origin)
     depth = _utils._get_depth(weights.shape, origin)
     depth, boundary = _utils._get_depth_boundary(image.ndim, depth, "none")
+
+    if mode == "wrap":
+        boundary = "periodic"
+        mode = "constant"
 
     result = image.map_overlap(
         dispatch_correlate(image),
@@ -60,7 +60,7 @@ def correlate(image,
         weights=weights,
         mode=mode,
         cval=cval,
-        origin=origin
+        origin=origin,
     )
 
     return result

--- a/dask_image/signal/__init__.py
+++ b/dask_image/signal/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+__all__ = [
+    "convolve",
+]
+
+from ._convolve import convolve
+
+
+
+
+
+
+convolve.__module__ = __name__

--- a/dask_image/signal/_convolve.py
+++ b/dask_image/signal/_convolve.py
@@ -1,0 +1,263 @@
+import numpy as np
+import dask.array as da
+
+def convolve(in1, in2, mode="full", method="fft", axes=None):
+    """Convolve a N-dimensional dask array with an N-dimensional array
+    using either the fft or the overlap-add method.
+
+    Some parts of this docstring are copied from scipy.signal.
+    Convolve `in1` and `in2`, with the output size determined by the
+    `mode` argument.
+
+    Parameters
+    ----------
+    in1 : parallel array
+        First input. Will be cast to a dask array
+
+    in2 : sequential array_like
+        Second input. Should have the same number of dimensions as `in1`.
+        Will be cast to a numpy array.
+
+    mode : str {'full', 'valid', 'same', 'periodic'}, optional
+        A string indicating the size of the output.
+
+        ``full``
+           The output is the full discrete linear convolution
+           of the inputs. (Default)
+        ``valid``
+           The output consists only of those elements that do not
+           rely on the zero-padding. In 'valid' mode, either `in1` or `in2`
+           must be at least as large as the other in every dimension.
+        ``same``
+           The output is the same size as `in1`, centered
+           with respect to the 'full' output.
+        ``periodic``
+           `in1` is assumed to be periodic for padding purposes, The output
+           is the same size as `in1`.
+
+    method : str {'oa', 'fft'}, optional
+        A string indicating which method to use to calculate the convolution.
+
+        ``oa``
+           Overlap-add method. This is generally much faster than `fft` when
+           `in1` is much larger than `in2` but can be slower when only a few
+           output values are needed or when the arrays are very similar in
+           shape and can only output float arrays (int or object array inputs
+           will be cast to float).
+        ``fft``
+           Convolve `in1` and `in2` using the fast Fourier transform method.
+           Can only output float arrays (int or object array inputs will be
+           cast to float). (Default)
+
+    axes : int or array_like of ints or None, optional
+        Axes over which to compute the convolution.
+        The default is over all axes.
+
+
+    Returns
+    -------
+    out : parallel array
+        An N-dimensional array containing a subset of the discrete linear
+        convolution of `in1` with `in2`.
+
+
+    See Also
+    --------
+    scipy.signal.oaconvolve : Equivalent Scipy operation for the overlap-add
+        method
+    scipy.signal.fftconvolve : Equivalent Scipy operation for the FFT
+        method
+
+
+    Notes
+    -----
+    This function is a work in progress and there are some possible improvements
+    that could be added.
+    These include but are not limited to:
+        * Working out the case where both input are dask arrays.
+        * Giving users the possibility to have the `mode` argument differ between axes.
+        * Giving users the possibility to use the direct convolution with sums as in ``scipy.signal.convolve``
+
+
+
+    Examples
+    --------
+    Convolve a 100,000 sample signal chunked in 100 1,000 elements chunks
+    with a 512-sample filter.
+
+    >>> from scipy import signal
+    >>> import dask.array as da
+    >>> rng = np.random.default_rng()
+    >>> sig = da.from_array(rng.standard_normal(100000), chunks = (1000,))
+    >>> filt = signal.firwin(512, 0.01)
+    >>> fsig = da.linalg.convolve(sig, filt).compute()
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, (ax_orig, ax_mag) = plt.subplots(2, 1)
+    >>> _ = ax_orig.plot(sig)
+    >>> _ = ax_orig.set_title('White noise')
+    >>> _ = ax_mag.plot(fsig)
+    >>> _ = ax_mag.set_title('Filtered noise')
+    >>> fig.tight_layout()
+    >>> fig.show()
+
+    References
+    ----------
+    .. [1] Wikipedia, "Overlap-add_method".
+           https://en.wikipedia.org/wiki/Overlap-add_method
+
+    .. [2] Richard G. Lyons. Understanding Digital Signal Processing,
+           Third Edition, 2011. Chapter 13.10.
+           ISBN 13: 978-0137-02741-5
+
+
+
+
+    """
+
+    from scipy.signal import fftconvolve, oaconvolve
+    from scipy.signal.signaltools import _init_freq_conv_axes
+
+
+    in1 = da.asarray(in1)
+    in2 = np.asarray(in2)
+
+    # Checking for trivial cases and incorrect flags
+    if in1.ndim == in2.ndim == 0:  # scalar inputs
+        return in1 * in2
+    elif in1.ndim != in2.ndim:
+        raise ValueError("in1 and in2 should have the same dimensionality")
+    elif in1.size == 0 or in2.size == 0:  # empty arrays
+        return np.array([])
+
+    if mode != "full" and mode != "same" and mode != "valid" and mode != "periodic":
+        raise ValueError(
+            "acceptable mode flags are 'valid'," " 'same', 'full' or 'periodic'"
+        )
+    if method not in ["fft", "oa"]:
+        raise ValueError("acceptable method flags are 'oa', or 'fft'")
+
+    # Pre-formatting or the the inputs, mainly for the `axes` argument
+    in1, in2, axes = _init_freq_conv_axes(in1, in2, mode, axes, sorted_axes=False)
+
+    # _init_freq_conv_axes calls a function that will swap out inputs if required
+    # when mode == "valid".We want to avoid having in2 be a dask array thus check
+    # to see if the inputs were swapped and raise an error.
+    if type(in1) == np.ndarray:
+        raise ValueError(
+            "For 'valid' mode in1 has to be at least as large as in2 in every dimension"
+        )
+
+    s1 = in1.shape
+    s2 = in2.shape
+
+    # If all axe were removed by the preformatting we only have to rely
+    # on multiplication broadcasting rules.
+    if not len(axes):
+        in_cv = in1 * in2
+        # This is the "full" output that is also valid.
+        # To get the "same" output we need to center in some dimensions.
+        if mode == "same" or mode == "periodic":
+            not_axes_but_s1_1 = [
+                a
+                for a in range(in1.ndim)
+                if a not in axes and s1[a] == 1 and s2[a] != 1
+            ]
+            in_cv = in_cv[
+                tuple(
+                    slice((s2[a] - 1) // 2, (s2[a] - 1) // 2 + 1)
+                    if a in not_axes_but_s1_1
+                    else slice(None, None)
+                    for a in range(in1.ndim)
+                )
+            ]
+            return in_cv
+
+    else:
+        # This iskind of a hack but it works. 
+        not_axes_but_s1_1 = [
+            a for a in range(in1.ndim) if a not in axes and s1[a] == 1 and s2[a] != 1
+        ]
+        if len(not_axes_but_s1_1) and (mode == "full" or mode == "valid"):
+            new_shape = tuple(
+                s1[i] for i in range(in1.ndim) if i not in not_axes_but_s1_1
+            )
+            in1 = in1.reshape(new_shape)
+            for a in not_axes_but_s1_1:
+                in1 = da.stack([in1] * s2[a], axis=a)
+            return convolve(in1, in2, mode=mode, method=method, axes=axes)
+
+        # Deals with the case where there is at least one axis a in which we do not
+        # do the convolution that has s2[a] == s1[a] != 1
+        not_axes_but_same_shape = [
+            a for a in range(in1.ndim) if a not in axes and s1[a] == s2[a] != 1
+        ]
+        if len(not_axes_but_same_shape):
+            to_rechunk = [a for a in not_axes_but_same_shape if len(in1.chunks[a]) != 1]
+            new_chunk_size = tuple(
+                -1 if a in to_rechunk else "auto" for a in range(in1.ndim)
+            )
+            in1 = in1.rechunk(new_chunk_size)
+
+        depth = {i: s2[i] // 2 for i in axes}
+
+        # Flags even dimensions and removes them by adding zeros
+        # This is done to avoid from having some results show up twice
+        # at the edge of blocks
+        even_flag = np.r_[[1 - s2[a] % 2 if a in axes else 0 for a in range(in1.ndim)]]
+        target_shape = np.asarray(s2)
+        target_shape += even_flag
+
+        if any(target_shape != np.asarray(s2)):
+            # padding axes where in2 is even
+            pad_width = tuple(
+                (even_flag[a], 0) if a in axes else (0, 0) for a in range(in1.ndim)
+            )
+            in2 = da.pad(in2, pad_width)
+
+        if mode != "valid":
+            pad_width = tuple(
+                (depth[i] - even_flag[i], depth[i]) if i in axes else (0, 0)
+                for i in range(in1.ndim)
+            )
+            in1 = da.pad(in1, pad_width)
+
+        if mode == "periodic":
+            boundary = "periodic"
+        else:
+            boundary = 0
+
+        cv_dict = {"oa": oaconvolve, "fft": fftconvolve}
+
+        cv_func = lambda x: cv_dict[method](x, in2, mode="same", axes=axes)
+
+        complex_result = in1.dtype.kind == "c" or in2.dtype.kind == "c"
+
+        if complex_result:
+            dtype = "complex"
+        else:
+            dtype = "float"
+
+        # Actualy does the convolution with all the parameters preformatted
+        in_cv = in1.map_overlap(
+            cv_func, depth=depth, boundary=boundary, trim=True, dtype=dtype
+        )
+
+        # The output as to be reduced depending on the `mode` argument
+        if mode == "valid":
+            output_slicing = tuple(
+                slice(depth[i], s1[i] - (depth[i] - even_flag[i]), 1)
+                if i in depth.keys()
+                else slice(0, None)
+                for i in range(in1.ndim)
+            )
+            in_cv = in_cv[output_slicing]
+
+        elif mode != "full":
+            # Only have to undo the padding
+            output_slicing = tuple(
+                slice(p[0], -p[1]) if p != (0, 0) else slice(0, None) for p in pad_width
+            )
+            in_cv = in_cv[output_slicing]
+
+    return in_cv

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "dask[array] >=0.16.1",
     "numpy >=1.11.3",
-    "scipy >=0.19.1",
+    "scipy >=1.4.0",
     "pims >=0.4.1",
 ]
 

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -154,3 +154,35 @@ def test_convolutions_compare(sp_func,
             d, weights, origin=origin
         )
     )
+@pytest.mark.parametrize(
+    "sp_func, da_func",
+    [
+        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
+    ]
+)
+@pytest.mark.parametrize(
+    "weights",
+    [
+     np.ones((1,5))
+     np.ones((5,1))
+    ]
+)
+@pytest.mark.parametrize(
+    "mode",
+    ["reflect","wrap","nearest","constant","mirror"])
+def test_convolutions_modes(sp_func,
+                            da_func,
+                            weights,
+                            mode):
+    a = np.arange(140).reshape(10,14)
+    d = da.from_array(a,chunks =(5, 7))
+    
+    da.utils.assert_eq(
+        sp_func(
+            a, weights, mode = mode
+        ),
+        da_func(
+            d, weights, mode = mode
+        )
+    )

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -164,8 +164,8 @@ def test_convolutions_compare(sp_func,
 @pytest.mark.parametrize(
     "weights",
     [
-     np.ones((1,5))
-     np.ones((5,1))
+     np.ones((1,5)),
+     np.ones((5,1)),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_signal/test__convolve.py
+++ b/tests/test_dask_image/test_signal/test__convolve.py
@@ -1,0 +1,391 @@
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from itertools import product
+
+import numpy as np
+import scipy.signal
+
+
+
+import dask.array as da
+from dask.array.utils import assert_eq
+from dask_image.signal import convolve 
+
+
+
+def test_convolve_invalid_shapes():
+    a = np.arange(1, 7).reshape((2, 3))
+    b = np.arange(-6, 0).reshape((3, 2))
+    with pytest.raises(
+        ValueError,
+        match="For 'valid' mode, one must be at least "
+        "as large as the other in every dimension",
+    ):
+        convolve(a, b, mode="valid")
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_convolve_invalid_shapes_axes(method):
+    a = np.zeros([5, 6, 2, 1])
+    b = np.zeros([5, 6, 3, 1])
+    with pytest.raises(
+        ValueError,
+        match=r"incompatible shapes for in1 and in2:"
+        r" \(5L?, 6L?, 2L?, 1L?\) and"
+        r" \(5L?, 6L?, 3L?, 1L?\)",
+    ):
+        convolve(a, b, method=method, axes=[0, 1])
+
+
+@pytest.mark.parametrize("a,b", [([1], 2), (1, [2]), ([3], [[2]])])
+def test_convolve_mismatched_dims(a, b):
+    with pytest.raises(
+        ValueError, match="in1 and in2 should have the same" " dimensionality"
+    ):
+        convolve(a, b)
+
+
+def test_convolve_invalid_flags():
+    with pytest.raises(
+        ValueError,
+        match="acceptable mode flags are 'valid'," " 'same', 'full' or 'periodic'",
+    ):
+        convolve([1], [2], mode="chips")
+
+    with pytest.raises(ValueError, match="acceptable method flags are 'oa', or 'fft'"):
+        convolve([1], [2], method="chips")
+
+    with pytest.raises(ValueError, match="when provided, axes cannot be empty"):
+        convolve([1], [2], axes=[])
+
+    with pytest.raises(
+        ValueError, match="axes must be a scalar or " "iterable of integers"
+    ):
+        convolve([1], [2], axes=[[1, 2], [3, 4]])
+
+    with pytest.raises(
+        ValueError, match="axes must be a scalar or " "iterable of integers"
+    ):
+        convolve([1], [2], axes=[1.0, 2.0, 3.0, 4.0])
+
+    with pytest.raises(ValueError, match="axes exceeds dimensionality of input"):
+        convolve([1], [2], axes=[1])
+
+    with pytest.raises(ValueError, match="axes exceeds dimensionality of input"):
+        convolve([1], [2], axes=[-2])
+
+    with pytest.raises(ValueError, match="all axes must be unique"):
+        convolve([1], [2], axes=[0, 0])
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_convolve_basic(method):
+    a = [3, 4, 5, 6, 5, 4]
+    b = [1, 2, 3]
+    c = convolve(a, b, method=method)
+    assert_eq(c, np.array([3, 10, 22, 28, 32, 32, 23, 12], dtype="float"))
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_convolve_same(method):
+    a = [3, 4, 5]
+    b = [1, 2, 3, 4]
+    c = convolve(a, b, mode="same", method=method)
+    assert_eq(c, np.array([10, 22, 34], dtype="float"))
+
+
+def test_convolve_broadcastable():
+    a = np.arange(27).reshape(3, 3, 3)
+    b = np.arange(3)
+    for i in range(3):
+        b_shape = [1] * 3
+        b_shape[i] = 3
+        x = convolve(a, b.reshape(b_shape), method="oa")
+        y = convolve(a, b.reshape(b_shape), method="fft")
+        assert_eq(x, y)
+
+
+def test_zero_rank():
+    a = 1289
+    b = 4567
+    c = convolve(a, b)
+    assert_eq(c, a * b)
+
+
+def test_single_element():
+    a = np.array([4967])
+    b = np.array([3920])
+    c = convolve(a, b)
+    assert_eq(c, a * b)
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_2d_arrays(method):
+    a = [[1, 2, 3], [3, 4, 5]]
+    b = [[2, 3, 4], [4, 5, 6]]
+    c = convolve(a, b, method=method)
+    d = np.array(
+        [[2, 7, 16, 17, 12], [10, 30, 62, 58, 38], [12, 31, 58, 49, 30]], dtype="float"
+    )
+    assert_eq(c, d)
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_input_swapping(method):
+    small = np.arange(8).reshape(2, 2, 2)
+    big = 1j * np.arange(27).reshape(3, 3, 3)
+    big += np.arange(27)[::-1].reshape(3, 3, 3)
+
+    out_array = np.array(
+        [
+            [
+                [0 + 0j, 26 + 0j, 25 + 1j, 24 + 2j],
+                [52 + 0j, 151 + 5j, 145 + 11j, 93 + 11j],
+                [46 + 6j, 133 + 23j, 127 + 29j, 81 + 23j],
+                [40 + 12j, 98 + 32j, 93 + 37j, 54 + 24j],
+            ],
+            [
+                [104 + 0j, 247 + 13j, 237 + 23j, 135 + 21j],
+                [282 + 30j, 632 + 96j, 604 + 124j, 330 + 86j],
+                [246 + 66j, 548 + 180j, 520 + 208j, 282 + 134j],
+                [142 + 66j, 307 + 161j, 289 + 179j, 153 + 107j],
+            ],
+            [
+                [68 + 36j, 157 + 103j, 147 + 113j, 81 + 75j],
+                [174 + 138j, 380 + 348j, 352 + 376j, 186 + 230j],
+                [138 + 174j, 296 + 432j, 268 + 460j, 138 + 278j],
+                [70 + 138j, 145 + 323j, 127 + 341j, 63 + 197j],
+            ],
+            [
+                [32 + 72j, 68 + 166j, 59 + 175j, 30 + 100j],
+                [68 + 192j, 139 + 433j, 117 + 455j, 57 + 255j],
+                [38 + 222j, 73 + 499j, 51 + 521j, 21 + 291j],
+                [12 + 144j, 20 + 318j, 7 + 331j, 0 + 182j],
+            ],
+        ]
+    )
+
+    assert_eq(convolve(small, big, "full", method=method), out_array)
+    assert_eq(convolve(big, small, "full", method=method), out_array)
+    assert_eq(convolve(small, big, "same", method=method), out_array[1:3, 1:3, 1:3])
+    assert_eq(convolve(big, small, "same", method=method), out_array[0:3, 0:3, 0:3])
+    assert_eq(convolve(big, small, "valid", method=method), out_array[1:3, 1:3, 1:3])
+
+    with pytest.raises(
+        ValueError,
+        match="For 'valid' mode in1 has to be at least as large as in2 in every dimension",
+    ):
+        convolve(small, big, "valid")
+
+
+@pytest.mark.parametrize("axes", ["", None, 0, [0], -1, [-1]])
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_convolve_real(axes, method):
+    a = np.array([1, 2, 3])
+    expected = np.array([1.0, 4.0, 10.0, 12.0, 9.0])
+
+    if axes == "":
+        out = convolve(a, a, method=method)
+    else:
+        out = convolve(a, a, method=method, axes=axes)
+    assert_eq(out, expected)
+
+
+@pytest.mark.parametrize("axes", [1, [1], -1, [-1]])
+@pytest.mark.parametrize("method", ["fft", "oa"])
+def test_convolve_real_axes(axes, method):
+    a = np.array([1, 2, 3])
+    expected = np.array([1.0, 4.0, 10.0, 12.0, 9.0])
+    a = np.tile(a, [2, 1])
+    expected = np.tile(expected, [2, 1])
+
+    out = convolve(a, a, method=method, axes=axes)
+    assert_eq(out, expected)
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+@pytest.mark.parametrize("axes", ["", None, 0, [0], -1, [-1]])
+def test_convolve_complex(method, axes):
+    a = np.array([1 + 1j, 2 + 2j, 3 + 3j], dtype="complex")
+    expected = np.array([0 + 2j, 0 + 8j, 0 + 20j, 0 + 24j, 0 + 18j], dtype="complex")
+
+    if axes == "":
+        out = convolve(a, a, method=method)
+    else:
+        out = convolve(a, a, axes=axes, method=method)
+    assert_eq(out, expected)
+
+
+@pytest.mark.skip(reason="Utils function, not a test function")
+def gen_convolve_shapes(sizes):
+    return [(a, b) for a, b in product(sizes, repeat=2) if abs(a - b) > 3]
+
+
+@pytest.mark.skip(reason="Utils function, not a test function")
+def gen_convolve_shapes_eq(sizes):
+    return [(a, b) for a, b in product(sizes, repeat=2) if a >= b]
+
+
+@pytest.mark.skip(reason="Utils function, not a test function")
+def gen_convolve_shapes_2d(sizes):
+    shapes0 = gen_convolve_shapes_eq(sizes)
+    shapes1 = gen_convolve_shapes_eq(sizes)
+    shapes = [ishapes0 + ishapes1 for ishapes0, ishapes1 in zip(shapes0, shapes1)]
+
+    modes = ["full", "valid", "same"]
+    return [
+        ishapes + (imode,)
+        for ishapes, imode in product(shapes, modes)
+        if imode != "valid" or (ishapes[0] > ishapes[1] and ishapes[2] > ishapes[3])
+    ]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("method", ["fft", "oa"])
+@pytest.mark.parametrize(
+    "shape_a_0, shape_b_0",
+    gen_convolve_shapes_eq(list(range(100)) + list(range(100, 1000, 23))),
+)
+def test_convolve_real_manylens(method, shape_a_0, shape_b_0):
+    a = np.random.rand(shape_a_0)
+    b = np.random.rand(shape_b_0)
+
+    expected = scipy.signal.fftconvolve(a, b)
+
+    out = convolve(a, b, method=method)
+    assert_eq(out, expected)
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+@pytest.mark.parametrize("shape_a_0, shape_b_0", gen_convolve_shapes([50, 47, 6, 4]))
+@pytest.mark.parametrize("is_complex", [True, False])
+@pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_convolve_1d_noaxes(shape_a_0, shape_b_0, is_complex, mode, method, chunks):
+
+    a = np.random.rand(shape_a_0)
+    b = np.random.rand(shape_b_0)
+    if is_complex:
+        a = a + 1j * np.random.rand(shape_a_0)
+        b = b + 1j * np.random.rand(shape_b_0)
+    if mode != "valid" or (shape_a_0 > shape_b_0):
+        a = da.from_array(a, chunks=chunks)
+
+        expected = scipy.signal.fftconvolve(a, b, mode=mode)
+
+        out = convolve(a, b, mode=mode, method=method)
+
+        assert_eq(out, expected)
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+@pytest.mark.parametrize("axes", [0, 1])
+@pytest.mark.parametrize("shape_a_0, shape_b_0", gen_convolve_shapes([50, 47, 6, 4]))
+@pytest.mark.parametrize("shape_a_extra", [1, 3])
+@pytest.mark.parametrize("shape_b_extra", [1, 3])
+@pytest.mark.parametrize("is_complex", [True, False])
+@pytest.mark.parametrize("mode", ["full", "valid", "same"])
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_convolve_1d_axes(
+    axes,
+    shape_a_0,
+    shape_b_0,
+    shape_a_extra,
+    shape_b_extra,
+    is_complex,
+    mode,
+    method,
+    chunks,
+):
+    ax_a = [shape_a_extra] * 2
+    ax_b = [shape_b_extra] * 2
+    ax_a[axes] = shape_a_0
+    ax_b[axes] = shape_b_0
+
+    a = np.random.rand(*ax_a)
+    b = np.random.rand(*ax_b)
+    if is_complex:
+        a = a + 1j * np.random.rand(*ax_a)
+        b = b + 1j * np.random.rand(*ax_b)
+
+    if mode != "valid" or a.shape[axes] > b.shape[axes]:
+        a = da.from_array(a, chunks=chunks)
+
+        expected = scipy.signal.fftconvolve(a, b, mode=mode, axes=axes)
+
+        out = convolve(a, b, mode=mode, method=method, axes=axes)
+
+        assert_eq(out, expected)
+
+
+@pytest.mark.parametrize("method", ["fft", "oa"])
+@pytest.mark.parametrize(
+    "shape_a_0, shape_b_0, " "shape_a_1, shape_b_1, mode",
+    gen_convolve_shapes_2d([50, 47, 6, 4]),
+)
+@pytest.mark.parametrize("is_complex", [True, False])
+@pytest.mark.parametrize("chunks", [15, 25])
+def test_convolve_2d_noaxes(
+    shape_a_0, shape_b_0, shape_a_1, shape_b_1, mode, is_complex, method, chunks
+):
+    a = np.random.rand(shape_a_0, shape_a_1)
+    b = np.random.rand(shape_b_0, shape_b_1)
+    if is_complex:
+        a = a + 1j * np.random.rand(shape_a_0, shape_a_1)
+        b = b + 1j * np.random.rand(shape_b_0, shape_b_1)
+
+    a = da.from_array(a, chunks=chunks)
+
+    expected = scipy.signal.fftconvolve(a, b, mode=mode)
+
+    out = convolve(a, b, mode=mode, method=method)
+
+    assert_eq(out, expected)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("method", ["fft", "oa"])
+@pytest.mark.parametrize("axes", [[0, 1], [0, 2], [1, 2]])
+@pytest.mark.parametrize(
+    "shape_a_0, shape_b_0, " "shape_a_1, shape_b_1, mode",
+    gen_convolve_shapes_2d([50, 47, 6, 4]),
+)
+@pytest.mark.parametrize("shape_a_extra", [1, 3])
+@pytest.mark.parametrize("shape_b_extra", [1, 3])
+@pytest.mark.parametrize("is_complex", [True, False])
+@pytest.mark.parametrize("chunks", [15, 25])
+def test_convolve_2d_axes(
+    axes,
+    shape_a_0,
+    shape_b_0,
+    shape_a_1,
+    shape_b_1,
+    mode,
+    shape_a_extra,
+    shape_b_extra,
+    is_complex,
+    method,
+    chunks,
+):
+    ax_a = [shape_a_extra] * 3
+    ax_b = [shape_b_extra] * 3
+    ax_a[axes[0]] = shape_a_0
+    ax_b[axes[0]] = shape_b_0
+    ax_a[axes[1]] = shape_a_1
+    ax_b[axes[1]] = shape_b_1
+
+    a = np.random.rand(*ax_a)
+    b = np.random.rand(*ax_b)
+    if is_complex:
+        a = a + 1j * np.random.rand(*ax_a)
+        b = b + 1j * np.random.rand(*ax_b)
+
+    a = da.from_array(a, chunks=chunks)
+    expected = scipy.signal.fftconvolve(a, b, mode=mode, axes=axes)
+
+    out = convolve(a, b, mode=mode, method=method, axes=axes)
+
+    assert_eq(out, expected)


### PR DESCRIPTION
This pull request is the result of another pull request on the main dask repository:  https://github.com/dask/dask/pull/8149

The convolution function has been added in the newly created dask_image.signal. Appropriate tests (that I couldn't run on my computer for some reason) have also been added in `test_dask_image/test_signal/`. There is also a docstring for the function though I don't understand why dask and dask_image build different HTML pages with the exact same docstring. 

Finally, while I was directed here by the core dask team, I personally think that this is even more confusing than adding the convolution in `dask.array` because it has basically nothing to do with `scipy.ndimage` or image processing in general. 