### PR TITLE
Use new Dask docs theme

### DIFF
--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -7,10 +7,10 @@ dependencies:
   - pip==20.2.4
   - wheel==0.35.1
   - sphinx==3.2.1
-  - dask-sphinx-theme==1.3.5
+  - dask-sphinx-theme>=2
   - dask==2.8.1
   - numpy==1.15.4
   - pims==0.4.1
   - slicerator==0.9.8
   - pip:
-    - slicerator==0.9.8
+      - slicerator==0.9.8


### PR DESCRIPTION
Bumping the minimum docs theme to use the new version. This isn't strictly necessary but I wanted to raise a PR to trigger the rtd preview and check everything looks ok.

xref dask/dask-sphinx-theme#54