### PR TITLE
Switch imread function to dask.array.image method

### DIFF
--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -4,6 +4,7 @@ import numbers
 import warnings
 
 import dask.array as da
+import dask.array.image
 import numpy as np
 import pims
 
@@ -31,69 +32,22 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
     array : dask.array.Array
         A Dask Array representing the contents of all image files.
     """
-
     sfname = str(fname)
     if not isinstance(nframes, numbers.Integral):
         raise ValueError("`nframes` must be an integer.")
     if (nframes != -1) and not (nframes > 0):
         raise ValueError("`nframes` must be greater than zero.")
 
-    if arraytype == "numpy":
-        arrayfunc = np.asanyarray
-    elif arraytype == "cupy":   # pragma: no cover
+    if arraytype == "cupy":   # pragma: no cover
         import cupy
-        arrayfunc = cupy.asanyarray
-
-    with pims.open(sfname) as imgs:
-        shape = (len(imgs),) + imgs.frame_shape
-        dtype = np.dtype(imgs.pixel_type)
-
-    if nframes == -1:
-        nframes = shape[0]
-
-    if nframes > shape[0]:
-        warnings.warn(
-            "`nframes` larger than number of frames in file."
-            " Will truncate to number of frames in file.",
-            RuntimeWarning
-        )
-    elif shape[0] % nframes != 0:
-        warnings.warn(
-            "`nframes` does not nicely divide number of frames in file."
-            " Last chunk will contain the remainder.",
-            RuntimeWarning
-        )
-
-    # place source filenames into dask array
-    filenames = sorted(glob.glob(sfname))  # pims also does this
-    if len(filenames) > 1:
-        ar = da.from_array(filenames, chunks=(nframes,))
-        multiple_files = True
+        preprocess = cupy.asanyarray
     else:
-        ar = da.from_array(filenames * shape[0], chunks=(nframes,))
-        multiple_files = False
+        preprocess = None
 
-    # read in data using encoded filenames
-    a = ar.map_blocks(
-        _map_read_frame,
-        chunks=da.core.normalize_chunks(
-            (nframes,) + shape[1:], shape),
-        multiple_files=multiple_files,
-        new_axis=list(range(1, len(shape))),
-        arrayfunc=arrayfunc,
-        meta=arrayfunc([]).astype(dtype),  # meta overwrites `dtype` argument
-    )
+    result = dask.array.image.imread(fname, preprocess=preprocess)
 
-    return a
+    if nframes != 1:
+        chunks = [nframes] + ['auto' for _ in range(result.ndim - 1)]
+        result = result.rechunk(chunks=chunks)
 
-
-def _map_read_frame(x, multiple_files, block_info=None, **kwargs):
-
-    fn = x[0]  # get filename from input chunk
-
-    if multiple_files:
-        i, j = 0, 1
-    else:
-        i, j = block_info[None]['array-location'][0]
-
-    return _utils._read_frame(fn=fn, i=slice(i, j), **kwargs)
+    return result

--- a/dask_image/imread/_utils.py
+++ b/dask_image/imread/_utils.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-import numpy as np
-import pims
-
-
-def _read_frame(fn, i, *, arrayfunc=np.asanyarray):
-    with pims.open(fn) as imgs:
-        return arrayfunc(imgs[i])


### PR DESCRIPTION
Work in progress PR for discussion

Benchmarking has shown that the `dask.array.image.imread` function is faster than the implementation here. We'd like to switch to using that one instead, the main question here is how disruptive or not it will be for our users.