### PR TITLE
Set up gpuCI testing on PRs

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -1,0 +1,13 @@
+PYTHON_VER:
+- "3.8"
+
+CUDA_VER:
+- "11.2"
+
+LINUX_VER:
+- ubuntu18.04
+
+RAPIDS_VER:
+- "22.02"
+
+excludes:

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -1,0 +1,58 @@
+##############################################
+# Dask GPU build and test script for CI      #
+##############################################
+set -e
+NUMARGS=$#
+ARGS=$*
+
+# Arg parsing function
+function hasArg {
+    (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
+}
+
+# Set path and build parallel level
+export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
+
+# Set home to the job's workspace
+export HOME="$WORKSPACE"
+
+# Switch to project root; also root of repo checkout
+cd "$WORKSPACE"
+
+# Determine CUDA release version
+export CUDA_REL=${CUDA_VERSION%.*}
+
+################################################################################
+# SETUP - Check environment
+################################################################################
+
+gpuci_logger "Check environment variables"
+env
+
+gpuci_logger "Check GPU usage"
+nvidia-smi
+
+gpuci_logger "Activate conda env"
+. /opt/conda/etc/profile.d/conda.sh
+conda activate dask_image
+
+gpuci_logger "Install cupy"
+python -m pip install cupy-cuda112 -f https://pip.cupy.dev/pre
+
+# gpuci_logger "Install dask"
+# python -m pip install git+https://github.com/dask/dask
+
+gpuci_logger "Install dask-image"
+python setup.py install
+
+gpuci_logger "Check Python versions"
+python --version
+
+gpuci_logger "Check conda environment"
+conda info
+conda config --show-sources
+conda list --show-channel-urls
+
+gpuci_logger "Python py.test for distributed"
+py.test $WORKSPACE -v -m cupy --junitxml="$WORKSPACE/junit-dask-image.xml"


### PR DESCRIPTION
This PR adds the required build files to run gpuCI on all PRs opened in this repo; based on these files, the `cupy` marked tests in this repo would be run in an environment with:

- ubuntu 18.04
- python 3.8
- cudatoolkit 11.2
- the latest pre-release of cupy
- (note that since tests here do not depend on a RAPIDS release, `RAPIDS_VER` has no impact on the environment)

Some additional things that should be done:

- [ ] adding documentation for gpuCI
- [ ] adding a description for the `cupy` label being used by pytest in gpuCI

Note that gpuCI is not currently enabled on this repo - ideally, that would be done after merging these files in. To see an example of the gpuCI checks running, view https://github.com/charlesbluca/dask-image/pull/1.

cc @jakirkham @GenevieveBuckley 