### PR TITLE
Remove `RAPIDS_VER` axis, bump `CUDA_VER` in gpuCI matrix

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -2,7 +2,7 @@ PYTHON_VER:
 - "3.8"
 
 CUDA_VER:
-- "11.2"
+- "11.5"
 
 LINUX_VER:
 - ubuntu18.04

--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -7,7 +7,4 @@ CUDA_VER:
 LINUX_VER:
 - ubuntu18.04
 
-RAPIDS_VER:
-- "22.02"
-
 excludes:

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -54,5 +54,5 @@ conda info
 conda config --show-sources
 conda list --show-channel-urls
 
-gpuci_logger "Python py.test for distributed"
+gpuci_logger "Python py.test for dask-image"
 py.test $WORKSPACE -v -m cupy --junitxml="$WORKSPACE/junit-dask-image.xml"


### PR DESCRIPTION
Makes some updates to the gpuCI matrix which should be passing once it is enabled on this repo:

- Removes `RAPIDS_VER` from the build matrix, as no RAPIDS projects are required for the cupy tests
- Bumps `CUDA_VER` to 11.5; as of https://github.com/rapidsai/dask-build-environment/pull/24 we are now only building Dask gpuCI images using CUDA 11.5 to match up with the gpuCI testing ran on RAPIDS projects