### PR TITLE
Update min python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     cmdclass=cmdclasses,
     packages=setuptools.find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=requirements,
     license="BSD 3-Clause",
     zip_safe=False,


### PR DESCRIPTION
The minimum supported python version tested with CI is python 3.6. 

That's been the case for a while, I just missed this one spot when we bumped the versions in https://github.com/dask/dask-image/pull/131