### PR TITLE
Docs: Add `find_objects` to the coverage table

### DIFF
--- a/docs/coverage.rst
+++ b/docs/coverage.rst
@@ -70,7 +70,7 @@ This table shows which SciPy ndimage functions are supported by dask-image.
      - ✓
    * - ``find_objects``
      - ✓
-     -
+     - ✓
    * - ``fourier_ellipsoid``
      - ✓
      -


### PR DESCRIPTION
Because of course I noticed this update was missing from the docs as soon as I merged https://github.com/dask/dask-image/pull/240
