### PR TITLE
Avoid DeprecationWarnings when importing scipy.ndimage filter functions

### DIFF
--- a/dask_image/dispatch/_dispatch_ndfilters.py
+++ b/dask_image/dispatch/_dispatch_ndfilters.py
@@ -46,7 +46,7 @@ dispatch_threshold_local_mean = Dispatcher(name="dispatch_threshold_local_mean")
 # ================== convolve ==================
 @dispatch_convolve.register(np.ndarray)
 def numpy_convolve(*args, **kwargs):
-    return scipy.ndimage.filters.convolve
+    return scipy.ndimage.convolve
 
 
 @dispatch_convolve.register_lazy("cupy")
@@ -62,7 +62,7 @@ def register_cupy_convolve():
 # ================== correlate ==================
 @dispatch_correlate.register(np.ndarray)
 def numpy_correlate(*args, **kwargs):
-    return scipy.ndimage.filters.correlate
+    return scipy.ndimage.correlate
 
 
 @dispatch_correlate.register_lazy("cupy")
@@ -78,7 +78,7 @@ def register_cupy_correlate():
 # ================== laplace ==================
 @dispatch_laplace.register(np.ndarray)
 def numpy_laplace(*args, **kwargs):
-    return scipy.ndimage.filters.laplace
+    return scipy.ndimage.laplace
 
 
 @dispatch_laplace.register_lazy("cupy")
@@ -94,7 +94,7 @@ def register_cupy_laplace():
 # ================== prewitt ==================
 @dispatch_prewitt.register(np.ndarray)
 def numpy_prewitt(*args, **kwargs):
-    return scipy.ndimage.filters.prewitt
+    return scipy.ndimage.prewitt
 
 
 @dispatch_prewitt.register_lazy("cupy")
@@ -110,7 +110,7 @@ def register_cupy_prewitt():
 # ================== sobel ==================
 @dispatch_sobel.register(np.ndarray)
 def numpy_sobel(*args, **kwargs):
-    return scipy.ndimage.filters.sobel
+    return scipy.ndimage.sobel
 
 
 @dispatch_sobel.register_lazy("cupy")
@@ -126,7 +126,7 @@ def register_cupy_sobel():
 # ================== gaussian_filter ==================
 @dispatch_gaussian_filter.register(np.ndarray)
 def numpy_gaussian_filter(*args, **kwargs):
-    return scipy.ndimage.filters.gaussian_filter
+    return scipy.ndimage.gaussian_filter
 
 
 @dispatch_gaussian_filter.register_lazy("cupy")
@@ -142,7 +142,7 @@ def register_cupy_gaussian_filter():
 # ================== gaussian_gradient_magnitude ==================
 @dispatch_gaussian_gradient_magnitude.register(np.ndarray)
 def numpy_gaussian_gradient_magnitude(*args, **kwargs):
-    return scipy.ndimage.filters.gaussian_gradient_magnitude
+    return scipy.ndimage.gaussian_gradient_magnitude
 
 
 @dispatch_gaussian_gradient_magnitude.register_lazy("cupy")
@@ -158,7 +158,7 @@ def register_cupy_gaussian_gradient_magnitude():
 # ================== gaussian_laplace ==================
 @dispatch_gaussian_laplace.register(np.ndarray)
 def numpy_gaussian_laplace(*args, **kwargs):
-    return scipy.ndimage.filters.gaussian_laplace
+    return scipy.ndimage.gaussian_laplace
 
 
 @dispatch_gaussian_laplace.register_lazy("cupy")
@@ -174,7 +174,7 @@ def register_cupy_gaussian_laplace():
 # ================== generic_filter ==================
 @dispatch_generic_filter.register(np.ndarray)
 def numpy_generic_filter(*args, **kwargs):
-    return scipy.ndimage.filters.generic_filter
+    return scipy.ndimage.generic_filter
 
 
 @dispatch_generic_filter.register_lazy("cupy")
@@ -190,7 +190,7 @@ def register_cupy_generic_filter():
 # ================== minimum_filter ==================
 @dispatch_minimum_filter.register(np.ndarray)
 def numpy_minimum_filter(*args, **kwargs):
-    return scipy.ndimage.filters.minimum_filter
+    return scipy.ndimage.minimum_filter
 
 
 @dispatch_minimum_filter.register_lazy("cupy")
@@ -206,7 +206,7 @@ def register_cupy_minimum_filter():
 # ================== median_filter ==================
 @dispatch_median_filter.register(np.ndarray)
 def numpy_median_filter(*args, **kwargs):
-    return scipy.ndimage.filters.median_filter
+    return scipy.ndimage.median_filter
 
 
 @dispatch_median_filter.register_lazy("cupy")
@@ -222,7 +222,7 @@ def register_cupy_median_filter():
 # ================== maximum_filter ==================
 @dispatch_maximum_filter.register(np.ndarray)
 def numpy_maximum_filter(*args, **kwargs):
-    return scipy.ndimage.filters.maximum_filter
+    return scipy.ndimage.maximum_filter
 
 
 @dispatch_maximum_filter.register_lazy("cupy")
@@ -238,7 +238,7 @@ def register_cupy_maximum_filter():
 # ================== rank_filter ==================
 @dispatch_rank_filter.register(np.ndarray)
 def numpy_rank_filter(*args, **kwargs):
-    return scipy.ndimage.filters.rank_filter
+    return scipy.ndimage.rank_filter
 
 
 @dispatch_rank_filter.register_lazy("cupy")
@@ -254,7 +254,7 @@ def register_cupy_rank_filter():
 # ================== percentile_filter ==================
 @dispatch_percentile_filter.register(np.ndarray)
 def numpy_percentile_filter(*args, **kwargs):
-    return scipy.ndimage.filters.percentile_filter
+    return scipy.ndimage.percentile_filter
 
 
 @dispatch_percentile_filter.register_lazy("cupy")
@@ -270,7 +270,7 @@ def register_cupy_percentile_filter():
 # ================== uniform_filter ==================
 @dispatch_uniform_filter.register(np.ndarray)
 def numpy_uniform_filter(*args, **kwargs):
-    return scipy.ndimage.filters.uniform_filter
+    return scipy.ndimage.uniform_filter
 
 
 @dispatch_uniform_filter.register_lazy("cupy")

--- a/dask_image/ndfilters/_conv.py
+++ b/dask_image/ndfilters/_conv.py
@@ -12,7 +12,7 @@ __all__ = [
 ]
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.convolve)
+@_utils._update_wrapper(scipy.ndimage.convolve)
 def convolve(image, weights, mode="reflect", cval=0.0, origin=0):
     check_arraytypes_compatible(image, weights)
 
@@ -39,7 +39,7 @@ def convolve(image, weights, mode="reflect", cval=0.0, origin=0):
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.correlate)
+@_utils._update_wrapper(scipy.ndimage.correlate)
 def correlate(image, weights, mode="reflect", cval=0.0, origin=0):
     check_arraytypes_compatible(image, weights)
 

--- a/dask_image/ndfilters/_diff.py
+++ b/dask_image/ndfilters/_diff.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.laplace)
+@_utils._update_wrapper(scipy.ndimage.laplace)
 def laplace(image, mode='reflect', cval=0.0):
     result = image.map_overlap(
         dispatch_laplace(image),

--- a/dask_image/ndfilters/_edge.py
+++ b/dask_image/ndfilters/_edge.py
@@ -21,7 +21,7 @@ def _validate_axis(ndim, axis):
         raise ValueError("The axis is out of range.")
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.prewitt)
+@_utils._update_wrapper(scipy.ndimage.prewitt)
 def prewitt(image, axis=-1, mode='reflect', cval=0.0):
     _validate_axis(image.ndim, axis)
 
@@ -39,7 +39,7 @@ def prewitt(image, axis=-1, mode='reflect', cval=0.0):
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.sobel)
+@_utils._update_wrapper(scipy.ndimage.sobel)
 def sobel(image, axis=-1, mode='reflect', cval=0.0):
     _validate_axis(image.ndim, axis)
 

--- a/dask_image/ndfilters/_gaussian.py
+++ b/dask_image/ndfilters/_gaussian.py
@@ -55,7 +55,7 @@ def _get_border(image, sigma, truncate):
     return half_shape
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.gaussian_filter)
+@_utils._update_wrapper(scipy.ndimage.gaussian_filter)
 def gaussian_filter(image,
                     sigma,
                     order=0,
@@ -98,7 +98,7 @@ def gaussian(image,
                            truncate=truncate)
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.gaussian_gradient_magnitude)
+@_utils._update_wrapper(scipy.ndimage.gaussian_gradient_magnitude)
 def gaussian_gradient_magnitude(image,
                                 sigma,
                                 mode='reflect',
@@ -126,7 +126,7 @@ def gaussian_gradient_magnitude(image,
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.gaussian_laplace)
+@_utils._update_wrapper(scipy.ndimage.gaussian_laplace)
 def gaussian_laplace(image,
                      sigma,
                      mode='reflect',

--- a/dask_image/ndfilters/_generic.py
+++ b/dask_image/ndfilters/_generic.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.generic_filter)
+@_utils._update_wrapper(scipy.ndimage.generic_filter)
 def generic_filter(image,
                    function,
                    size=None,

--- a/dask_image/ndfilters/_order.py
+++ b/dask_image/ndfilters/_order.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.minimum_filter)
+@_utils._update_wrapper(scipy.ndimage.minimum_filter)
 def minimum_filter(image,
                    size=None,
                    footprint=None,
@@ -45,7 +45,7 @@ def minimum_filter(image,
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.median_filter)
+@_utils._update_wrapper(scipy.ndimage.median_filter)
 def median_filter(image,
                   size=None,
                   footprint=None,
@@ -72,7 +72,7 @@ def median_filter(image,
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.maximum_filter)
+@_utils._update_wrapper(scipy.ndimage.maximum_filter)
 def maximum_filter(image,
                    size=None,
                    footprint=None,
@@ -99,7 +99,7 @@ def maximum_filter(image,
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.rank_filter)
+@_utils._update_wrapper(scipy.ndimage.rank_filter)
 def rank_filter(image,
                 rank,
                 size=None,
@@ -128,7 +128,7 @@ def rank_filter(image,
     return result
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.percentile_filter)
+@_utils._update_wrapper(scipy.ndimage.percentile_filter)
 def percentile_filter(image,
                       percentile,
                       size=None,

--- a/dask_image/ndfilters/_smooth.py
+++ b/dask_image/ndfilters/_smooth.py
@@ -14,7 +14,7 @@ __all__ = [
 gaussian_filter = gaussian_filter
 
 
-@_utils._update_wrapper(scipy.ndimage.filters.uniform_filter)
+@_utils._update_wrapper(scipy.ndimage.uniform_filter)
 def uniform_filter(image,
                    size=3,
                    mode='reflect',

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip==20.2.4
   - wheel==0.35.1
   - sphinx==3.2.1
+  - jinja2<3.1
   - dask==2.8.1
   - numpy==1.15.4
   - pims==0.4.1

--- a/tests/test_dask_image/test_ndfilters/test__conv.py
+++ b/tests/test_dask_image/test_ndfilters/test__conv.py
@@ -88,8 +88,8 @@ def test_convolutions_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
-        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
+        (scipy.ndimage.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.correlate, dask_image.ndfilters.correlate),
     ]
 )
 @pytest.mark.parametrize(
@@ -117,8 +117,8 @@ def test_convolutions_identity(sp_func,
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
-        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
+        (scipy.ndimage.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.correlate, dask_image.ndfilters.correlate),
     ]
 )
 @pytest.mark.parametrize(
@@ -157,8 +157,8 @@ def test_convolutions_compare(sp_func,
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.convolve, dask_image.ndfilters.convolve),
-        (scipy.ndimage.filters.correlate, dask_image.ndfilters.correlate),
+        (scipy.ndimage.convolve, dask_image.ndfilters.convolve),
+        (scipy.ndimage.correlate, dask_image.ndfilters.correlate),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_image/test_ndfilters/test__diff.py
+++ b/tests/test_dask_image/test_ndfilters/test__diff.py
@@ -27,6 +27,5 @@ def test_laplace_compare():
     d = da.from_array(a, chunks=(5, 5, 6))
 
     da.utils.assert_eq(
-        scipy.ndimage.filters.laplace(a),
-        dask_image.ndfilters.laplace(d)
+        scipy.ndimage.laplace(a), dask_image.ndfilters.laplace(d)
     )

--- a/tests/test_dask_image/test_ndfilters/test__edge.py
+++ b/tests/test_dask_image/test_ndfilters/test__edge.py
@@ -66,8 +66,8 @@ def test_edge_comprehensions(da_func):
 @pytest.mark.parametrize(
     "da_func, sp_func",
     [
-        (dask_image.ndfilters.prewitt, scipy.ndimage.filters.prewitt),
-        (dask_image.ndfilters.sobel, scipy.ndimage.filters.sobel),
+        (dask_image.ndfilters.prewitt, scipy.ndimage.prewitt),
+        (dask_image.ndfilters.sobel, scipy.ndimage.sobel),
     ]
 )
 def test_edge_func_compare(da_func, sp_func, axis):

--- a/tests/test_dask_image/test_ndfilters/test__gaussian.py
+++ b/tests/test_dask_image/test_ndfilters/test__gaussian.py
@@ -48,9 +48,7 @@ def test_gaussian_filters_params(da_func, err_type, sigma, truncate):
 )
 @pytest.mark.parametrize(
     "sp_func, da_func",
-    [
-        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),  # noqa: E501
-    ]
+    [(scipy.ndimage.gaussian_filter, dask_image.ndfilters.gaussian_filter)]
 )
 def test_gaussian_filters_identity(sp_func, da_func, order, sigma, truncate):
     a = np.arange(140.0).reshape(10, 14)
@@ -131,11 +129,10 @@ def test_gaussian_filter_comprehensions(da_func):
 @pytest.mark.parametrize(
     "sp_func, da_func",
     [
-        (scipy.ndimage.filters.gaussian_filter,
-         dask_image.ndfilters.gaussian_filter),
-        (scipy.ndimage.filters.gaussian_gradient_magnitude,
+        (scipy.ndimage.gaussian_filter, dask_image.ndfilters.gaussian_filter),
+        (scipy.ndimage.gaussian_gradient_magnitude,
          dask_image.ndfilters.gaussian_gradient_magnitude),
-        (scipy.ndimage.filters.gaussian_laplace,
+        (scipy.ndimage.gaussian_laplace,
          dask_image.ndfilters.gaussian_laplace),
     ]
 )
@@ -175,9 +172,7 @@ def test_gaussian_filters_compare(sp_func, da_func, sigma, truncate):
 )
 @pytest.mark.parametrize(
     "sp_func, da_func",
-    [
-        (scipy.ndimage.filters.gaussian_filter, dask_image.ndfilters.gaussian_filter),  # noqa: E501
-    ]
+    [(scipy.ndimage.gaussian_filter, dask_image.ndfilters.gaussian_filter)]
 )
 def test_gaussian_derivative_filters_compare(sp_func, da_func,
                                              order, sigma, truncate):

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -65,9 +65,7 @@ def test_generic_filter_shape_type(da_func):
 
 @pytest.mark.parametrize(
     "sp_func, da_func",
-    [
-        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),  # noqa: E501
-    ],
+    [(scipy.ndimage.generic_filter, dask_image.ndfilters.generic_filter)],
 )
 @pytest.mark.parametrize(
     "function, size, footprint",
@@ -112,9 +110,7 @@ def test_generic_filter_comprehensions(da_func):
 
 @pytest.mark.parametrize(
     "sp_func, da_func",
-    [
-        (scipy.ndimage.filters.generic_filter, dask_image.ndfilters.generic_filter),  # noqa: E501
-    ],
+    [(scipy.ndimage.generic_filter, dask_image.ndfilters.generic_filter)],
 )
 @pytest.mark.parametrize(
     "function, size, footprint, origin",

--- a/tests/test_dask_image/test_ndfilters/test__order.py
+++ b/tests/test_dask_image/test_ndfilters/test__order.py
@@ -82,15 +82,14 @@ def test_ordered_filter_shape_type(da_func,
 @pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
-        (scipy.ndimage.filters.minimum_filter,
+        (scipy.ndimage.minimum_filter,
          dask_image.ndfilters.minimum_filter, {}),
-        (scipy.ndimage.filters.median_filter,
-         dask_image.ndfilters.median_filter, {}),
-        (scipy.ndimage.filters.maximum_filter,
+        (scipy.ndimage.median_filter, dask_image.ndfilters.median_filter, {}),
+        (scipy.ndimage.maximum_filter,
          dask_image.ndfilters.maximum_filter, {}),
-        (scipy.ndimage.filters.rank_filter,
+        (scipy.ndimage.rank_filter,
          dask_image.ndfilters.rank_filter, {"rank": 0}),
-        (scipy.ndimage.filters.percentile_filter,
+        (scipy.ndimage.percentile_filter,
          dask_image.ndfilters.percentile_filter, {"percentile": 0}),
     ]
 )
@@ -146,15 +145,14 @@ def test_order_comprehensions(da_func, kwargs):
 @pytest.mark.parametrize(
     "sp_func, da_func, extra_kwargs",
     [
-        (scipy.ndimage.filters.minimum_filter,
+        (scipy.ndimage.minimum_filter,
          dask_image.ndfilters.minimum_filter, {}),
-        (scipy.ndimage.filters.median_filter,
-         dask_image.ndfilters.median_filter, {}),
-        (scipy.ndimage.filters.maximum_filter,
+        (scipy.ndimage.median_filter, dask_image.ndfilters.median_filter, {}),
+        (scipy.ndimage.maximum_filter,
          dask_image.ndfilters.maximum_filter, {}),
-        (scipy.ndimage.filters.rank_filter,
+        (scipy.ndimage.rank_filter,
          dask_image.ndfilters.rank_filter, {"rank": 1}),
-        (scipy.ndimage.filters.percentile_filter,
+        (scipy.ndimage.percentile_filter,
          dask_image.ndfilters.percentile_filter, {"percentile": 10}),
     ]
 )

--- a/tests/test_dask_image/test_ndfilters/test__smooth.py
+++ b/tests/test_dask_image/test_ndfilters/test__smooth.py
@@ -72,7 +72,7 @@ def test_uniform_identity(size, origin):
     )
 
     da.utils.assert_eq(
-        scipy.ndimage.filters.uniform_filter(a, size, origin=origin),
+        scipy.ndimage.uniform_filter(a, size, origin=origin),
         dask_image.ndfilters.uniform_filter(d, size, origin=origin)
     )
 
@@ -94,6 +94,6 @@ def test_uniform_compare(size, origin):
     d = da.from_array(a, chunks=(50, 55))
 
     da.utils.assert_eq(
-        scipy.ndimage.filters.uniform_filter(a, size, origin=origin),
+        scipy.ndimage.uniform_filter(a, size, origin=origin),
         dask_image.ndfilters.uniform_filter(d, size, origin=origin)
     )


### PR DESCRIPTION
Fix #260 

Import from `scipy.ndimage` rather than `scipy.ndimage.filters` as the filters namespace is now deprecated.