### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,9 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -14,4 +14,4 @@ dependencies:
   - slicerator==0.9.8
   - pip:
       - slicerator==0.9.8
-      - dask-sphinx-theme>=2
+      - dask-sphinx-theme>=3.0.0


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell