### PR TITLE
Use natural sorting in  `imread(...)` when globbing multiple files 

### DIFF
--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -25,8 +25,8 @@ def imread(fname, nframes=1, *, arraytype="numpy", sortfunc=sorted):
         Number of the frames to include in each chunk (default: 1).
     arraytype : str, optional
         Array type for dask chunks. Available options: "numpy", "cupy".
-    sortfunc: Callable
-        A function for sorting the glob results.
+    sortfunc: Callable, optional
+        A function for sorting the glob results, default is "sorted".
 
     Returns
     -------

--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -10,7 +10,7 @@ import pims
 from . import _utils
 
 
-def imread(fname, nframes=1, *, arraytype="numpy"):
+def imread(fname, nframes=1, *, arraytype="numpy", sortfunc=sorted):
     """
     Read image data into a Dask Array.
 
@@ -25,6 +25,8 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
         Number of the frames to include in each chunk (default: 1).
     arraytype : str, optional
         Array type for dask chunks. Available options: "numpy", "cupy".
+    sortfunc: Callable
+        A function for sorting the glob results.
 
     Returns
     -------
@@ -65,7 +67,7 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
         )
 
     # place source filenames into dask array
-    filenames = sorted(glob.glob(sfname))  # pims also does this
+    filenames = sortfunc(glob.glob(sfname))  # pims also does this
     if len(filenames) > 1:
         ar = da.from_array(filenames, chunks=(nframes,))
         multiple_files = True
@@ -83,7 +85,6 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
         arrayfunc=arrayfunc,
         meta=arrayfunc([]).astype(dtype),  # meta overwrites `dtype` argument
     )
-
     return a
 
 

--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -6,11 +6,12 @@ import warnings
 import dask.array as da
 import numpy as np
 import pims
+from tifffile import natural_sorted
 
 from . import _utils
 
 
-def imread(fname, nframes=1, *, arraytype="numpy", sortfunc=sorted):
+def imread(fname, nframes=1, *, arraytype="numpy"):
     """
     Read image data into a Dask Array.
 
@@ -21,12 +22,12 @@ def imread(fname, nframes=1, *, arraytype="numpy", sortfunc=sorted):
     ----------
     fname : str or pathlib.Path
         A glob like string that may match one or multiple filenames.
+        Where multiple filenames match, they are sorted using
+        natural (as opposed to alphabetical) sort.
     nframes : int, optional
         Number of the frames to include in each chunk (default: 1).
     arraytype : str, optional
         Array type for dask chunks. Available options: "numpy", "cupy".
-    sortfunc: Callable, optional
-        A function for sorting the glob results, default is "sorted".
 
     Returns
     -------
@@ -66,8 +67,8 @@ def imread(fname, nframes=1, *, arraytype="numpy", sortfunc=sorted):
             RuntimeWarning
         )
 
-    # place source filenames into dask array
-    filenames = sortfunc(glob.glob(sfname))  # pims also does this
+    # place source filenames into dask array after sorting
+    filenames = natural_sorted(glob.glob(sfname))
     if len(filenames) > 1:
         ar = da.from_array(filenames, chunks=(nframes,))
         multiple_files = True

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -97,15 +97,9 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype, is_pa
     da.utils.assert_eq(a, d)
 
 
-@pytest.mark.parametrize("sortfunc, expected", [
-                            pytest.param(sorted, np.array([[10], [9]])),
-                            pytest.param(tifffile.natural_sorted,
-                                         np.array([[9], [10]]))
-                            ])
-def test_tiff_imread_glob_sort(tmpdir, sortfunc, expected):
+def test_tiff_imread_glob_natural_sort(tmpdir):
     dirpth = tmpdir.mkdir("test_imread")
     tifffile.imwrite(dirpth.join("10.tif"), np.array([10]))
     tifffile.imwrite(dirpth.join("9.tif"), np.array([9]))
-    actual = np.array(dask_image.imread.imread(dirpth.join("*.tif"),
-                      sortfunc=sortfunc))
-    assert np.all(actual == expected)
+    actual = np.array(dask_image.imread.imread(dirpth.join("*.tif")))
+    assert np.all(actual == np.array([[9], [10]]))

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -98,12 +98,14 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype, is_pa
 
 
 @pytest.mark.parametrize("sortfunc, expected", [
-                            pytest.param(sorted, np.array([[10],[9]])), 
-                            pytest.param(tifffile.natural_sorted, np.array([[9],[10]]))
+                            pytest.param(sorted, np.array([[10], [9]])),
+                            pytest.param(tifffile.natural_sorted,
+                                         np.array([[9], [10]]))
                             ])
 def test_tiff_imread_glob_sort(tmpdir, sortfunc, expected):
     dirpth = tmpdir.mkdir("test_imread")
     tifffile.imwrite(dirpth.join("10.tif"), np.array([10]))
     tifffile.imwrite(dirpth.join("9.tif"), np.array([9]))
-    actual = np.array(dask_image.imread.imread(dirpth.join("*.tif"), sortfunc=sortfunc))
-    assert np.all(actual==expected)
+    actual = np.array(dask_image.imread.imread(dirpth.join("*.tif"),
+                      sortfunc=sortfunc))
+    assert np.all(actual == expected)

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -95,3 +95,15 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, runtime_warning, dtype, is_pa
         assert (shape[0] % nframes) == d.chunks[0][-1]
 
     da.utils.assert_eq(a, d)
+
+
+@pytest.mark.parametrize("sortfunc, expected", [
+                            pytest.param(sorted, np.array([[10],[9]])), 
+                            pytest.param(tifffile.natural_sorted, np.array([[9],[10]]))
+                            ])
+def test_tiff_imread_glob_sort(tmpdir, sortfunc, expected):
+    dirpth = tmpdir.mkdir("test_imread")
+    tifffile.imwrite(dirpth.join("10.tif"), np.array([10]))
+    tifffile.imwrite(dirpth.join("9.tif"), np.array([9]))
+    actual = np.array(dask_image.imread.imread(dirpth.join("*.tif"), sortfunc=sortfunc))
+    assert np.all(actual==expected)


### PR DESCRIPTION
`dask_image.imread.imread` can include glob strings in the filename argument.

Currently, the results of the glob operation are sorted using `sorted`, a behviour that is not described in the doctring.

`sorted` sorts alphabetically which causes files such as `10.tif`, `9.tif` to be read in this order, which is counter-intuitive.
A common strategy adopted by users to circumenvent such file name problems is to zero-pad all numbers in a string. 

This PR adds a `sortfunc` argument to to `imread`, which allows to pass in a custom sort function. A use case for this  is to pass in a function that performs natural sort, which will sort strings of numbers numerically. Such a use-case is shown in the included test.

The docstring for imread has been updated to include the new argument, which also remedies the current undocumented behaviour.
Files have been checked with `flake8`. 
