### PR TITLE
Setup Coveralls with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,20 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: pytest -v
+
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.test_number }}
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@1.1.3
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -v --cov=dask_image
+        run: pytest -v --cov=dask_image --cov-report lcov
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@1.1.3
@@ -46,6 +46,7 @@ jobs:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.test_number }}
           parallel: true
+          path-to-lcov: coverage.lcov
 
   finish:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest -v
+        run: pytest -v --cov=dask_image
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@1.1.3

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -10,6 +10,7 @@ dependencies:
   - coverage==6.3.1
   - flake8==4.0.1
   - pytest==7.0.0
+  - pytest-cov==4.0.0
   - pytest-flake8==1.0.7
   - dask==2.8.1
   - numpy==1.21.5

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -10,6 +10,7 @@ dependencies:
   - coverage==6.3.1
   - flake8==4.0.1
   - pytest==7.0.0
+  - pytest-cov==4.0.0
   - pytest-flake8==1.0.7
   - dask==2.8.1
   - numpy==1.22.2

--- a/continuous_integration/environment-3.9.yml
+++ b/continuous_integration/environment-3.9.yml
@@ -10,6 +10,7 @@ dependencies:
   - coverage==6.3
   - flake8==4.0.1
   - pytest==6.2.5
+  - pytest-cov==4.0.0
   - pytest-flake8==1.0.7
   - dask==2022.1.1
   - numpy==1.22.1


### PR DESCRIPTION
Previously Coveralls was setup with CI to receive coverage data and report any lines missed by testing. However this fell out of use due to a few migrations of CI in the interim, which often lacked support for Coveralls. Fortunately there is GitHub Actions support of Coveralls. So this sets up Coveralls support with GitHub Actions (along with any other refreshing needed).