### PR TITLE
Updates `setup.py`'s Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     cmdclass=cmdclasses,
     packages=setuptools.find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=requirements,
     license="BSD 3-Clause",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,10 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     tests_require=test_requirements
 )


### PR DESCRIPTION
* Bump `python_requires` to `3.8+`
* Update trove classifiers to include `3.8`-`3.11`