### PR TITLE
Require Dask 1.1.0+

### DIFF
--- a/dask_image/ndmeasure/_utils/__init__.py
+++ b/dask_image/ndmeasure/_utils/__init__.py
@@ -5,11 +5,6 @@ import dask
 import dask.array as da
 import numpy as np
 
-try:
-    from dask.array import blockwise as da_blockwise
-except ImportError:
-    from dask.array import atop as da_blockwise
-
 
 def _norm_input_labels_index(image, label_image=None, index=None):
     """
@@ -68,7 +63,7 @@ def _ravel_shape_indices(dimensions, dtype=int, chunks=None):
         for i, c in enumerate(chunks)
     ]
 
-    indices = da_blockwise(
+    indices = da.blockwise(
         _ravel_shape_indices_kernel, tuple(range(len(indices))),
         *sum([(a, (i,)) for i, a in enumerate(indices)], tuple()),
         dtype=dtype

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "dask[array] >=0.16.1",
+    "dask[array] >=1.1.0",
     "numpy >=1.11.3",
     "scipy >=0.19.1",
     "pims >=0.4.1",


### PR DESCRIPTION
Fixes https://github.com/dask/dask-image/issues/232

Bumps the Dask minimum version to 1.1.0, which in turn allows some special casing logic to be dropped.