### PR TITLE
Security update: Dask v2021.10.0 as minimum allowable version

### DIFF
--- a/continuous_integration/environment-3.11.yml
+++ b/continuous_integration/environment-3.11.yml
@@ -1,20 +1,20 @@
-name: dask-image-testenv-py311
+name: dask-image-testenv
 
 channels:
   - conda-forge
 
 dependencies:
   - python=3.11.*
-  - pip
-  - wheel
-  - coverage
-  - flake8
-  - pytest
-  - pytest-cov
-  - pytest-flake8
-  - dask
-  - numpy
-  - scipy
-  - scikit-image
-  - pims
-  - slicerator
+  - pip==23.0.1
+  - wheel==0.38.4
+  - coverage==7.2.1
+  - flake8==6.0.0
+  - pytest==7.2.2
+  - pytest-cov==4.0.0
+  - pytest-flake8==1.1.1
+  - dask==2023.3.1
+  - numpy==1.24.2
+  - scipy==1.10.1
+  - scikit-image==0.19.3
+  - pims==0.6.1
+  - slicerator==1.1.0

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest==7.0.0
   - pytest-cov==4.0.0
   - pytest-flake8==1.0.7
-  - dask==2.8.1
+  - dask==2021.10.0
   - numpy==1.22.2
   - scipy==1.8.0
   - scikit-image==0.19.1

--- a/continuous_integration/environment-doc.yml
+++ b/continuous_integration/environment-doc.yml
@@ -9,7 +9,7 @@ dependencies:
   - wheel==0.37.1
   - sphinx==5.3.0
   - jinja2<3.1
-  - dask==2.8.1
+  - dask==2021.10.0
   - numpy==1.23.4
   - scipy==1.9.2
   - scikit-image==0.19.3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "dask[array] >=1.1.0",
+    "dask[array] >=2021.10.0",
     "numpy >=1.11.3",
     "scipy >=0.19.1",
     "pims >=0.4.1",


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/258

Dependabot suggests bumping the minimum allowable version of dask to v2021.10.0, as a security update.

> An issue was discovered in Dask (aka python-dask) through 2021.09.1. Single machine Dask clusters started with dask.distributed.LocalCluster or dask.distributed.Client (which defaults to using LocalCluster) would mistakenly configure their respective Dask workers to listen on external interfaces (typically with a randomly selected high port) rather than only on localhost. A Dask cluster created using this method (when running on a machine that has an applicable port exposed) could be used by a sophisticated attacker to achieve remote code execution.

Once this is done, we should probably also publish another release to PyPI (which would also solve issue https://github.com/dask/dask-image/issues/271)
