### PR TITLE
Update NaN block size tests for threshold_local function

### DIFF
--- a/dask_image/ndfilters/_threshold.py
+++ b/dask_image/ndfilters/_threshold.py
@@ -80,7 +80,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
                                                mode=mode, cval=cval)
     elif method == 'gaussian':
         if param is None:
-            sigma = (da.asarray(block_size) - 1) / 6.0
+            sigma = (da.asarray(block_size, like=image._meta) - 1) / 6.0
         else:
             sigma = param
         thresh_image = _gaussian.gaussian_filter(image, sigma, mode=mode,

--- a/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
+++ b/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
@@ -106,7 +106,6 @@ class TestInvalidArguments:
              [4, 5, 1, 0, 0]], dtype=int), chunks=(5, 5))
 
     @pytest.mark.parametrize("method, block_size, error_type", [
-        ('gaussian', cupy.nan, ValueError),
         ('median', cupy.nan, TypeError),
     ])
     def test_nan_blocksize(self, method, block_size, error_type):


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/256

This PR:
1. Removes some unnecessary tests. I wrote the tests several years ago, and I don't think there was a good reason to have them in there. It looks like I just wanted to have higher test code coverage at the time
2. It also explicitly specifies the `like=` kwarg when computing `sigma` from `block_size` for the gaussian local threshold function. I've found an edge case where `da.asarray(cupy_array)` correctly creates a dask array with cupy chunks, but `da.asarray(cupy.nan)` doesn't make a cupy-backed dask array (because `type(cupy.nan)` returns float). To avoid this problem, we use the `like=` kwarg to match the array type to the input image type.

