### PR TITLE
Group all imread functions together in the same file

### DIFF
--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -8,8 +8,6 @@ import numpy as np
 import pims
 from tifffile import natural_sorted
 
-from . import _utils
-
 
 def imread(fname, nframes=1, *, arraytype="numpy"):
     """
@@ -98,4 +96,9 @@ def _map_read_frame(x, multiple_files, block_info=None, **kwargs):
     else:
         i, j = block_info[None]['array-location'][0]
 
-    return _utils._read_frame(fn=fn, i=slice(i, j), **kwargs)
+    return _read_frame(fn=fn, i=slice(i, j), **kwargs)
+
+
+def _read_frame(fn, i, *, arrayfunc=np.asanyarray):
+    with pims.open(fn) as imgs:
+        return arrayfunc(imgs[i])

--- a/dask_image/imread/_utils.py
+++ b/dask_image/imread/_utils.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-import numpy as np
-import pims
-
-
-def _read_frame(fn, i, *, arrayfunc=np.asanyarray):
-    with pims.open(fn) as imgs:
-        return arrayfunc(imgs[i])


### PR DESCRIPTION
This PR groups all imread functions into the same file.

I find it annoying to have all the imread functions together, *except* for one little two line function which is split onto another page. It also makes it weirdly difficult to fully understand what is happening with the code, so I'm changing it.
