### PR TITLE
Test `find_objects` w/incorrect array type

### DIFF
--- a/tests/test_dask_image/test_ndmeasure/test_find_objects.py
+++ b/tests/test_dask_image/test_ndmeasure/test_find_objects.py
@@ -49,6 +49,12 @@ def label_image_with_empty_chunk():
     return label_image
 
 
+def test_find_objects_err(label_image):
+    label_image = label_image.astype(float)
+    with pytest.raises(ValueError):
+        dask_image.ndmeasure.find_objects(label_image)
+
+
 def test_find_objects(label_image):
     result = dask_image.ndmeasure.find_objects(label_image)
     assert isinstance(result, dd.DataFrame)


### PR DESCRIPTION
Increase test coverage of `find_objects` by testing this error case

https://github.com/dask/dask-image/blob/d25a1298636fec9f94840037ee6c0043a13ecb05/dask_image/ndmeasure/__init__.py#L229-L230