### PR TITLE
Make tifffile regular requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requirements = [
     "numpy >=1.11.3",
     "scipy >=0.19.1",
     "pims >=0.4.1",
+    "tifffile >=2018.10.18",
 ]
 
 test_requirements = [
@@ -40,7 +41,6 @@ test_requirements = [
     "pytest >=3.0.5",
     "pytest-flake8 >=0.8.1",
     "pytest-timeout >=1.0.0",
-    "tifffile >=2018.10.18",
 ]
 
 cmdclasses = {


### PR DESCRIPTION
I just realised that although `tifffile` is imported in `dask_image.imread.__init__`, it's only part of the test requirements. Indeed, this leads to an import error in a fresh environment.

This PR upgrades `tifffile >=2018.10.18` from a test requirement to a regular requirement in `setup.py`. Regarding the version, `2018.10.18`, which had been pinned as a test requirement, also provides `natural_sorted` as introduced in https://github.com/dask/dask-image/pull/265.