### PR TITLE
Update release notes script

### DIFF
--- a/docs/release/generate_release_notes.py
+++ b/docs/release/generate_release_notes.py
@@ -134,6 +134,7 @@ other_pull_requests = {}
 for pull in tqdm(
     g.search_issues(
         f'repo:{GH_USER}/{GH_REPO} '
+        f'is:pull-request '
         f'merged:>{previous_tag_date.isoformat()} '
         'sort:created-asc'
     ),


### PR DESCRIPTION
The release notes script generated produced an error, so this small update makes it work again for newer versions of `pygithub`.

Honestly most of this functionality is now included as part of the Github release page (https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) so we could potentially get rid of the script altogether.