### PR TITLE
Require NumPy 1.18+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "dask[array] >=2021.10.0",
-    "numpy >=1.11.3",
+    "numpy >=1.18",
     "scipy >=0.19.1",
     "pims >=0.4.1",
     "tifffile >=2018.10.18",


### PR DESCRIPTION
This aligns with Dask 2021.10.0's own NumPy requirement.

https://github.com/dask/dask/blob/2021.10.0/setup.py#L13