### PR TITLE
Update GPU conda environment before running tests

### DIFF
--- a/continuous_integration/environment-3.10.yml
+++ b/continuous_integration/environment-3.10.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10.*
   - pip==23.0.1
   - wheel==0.38.4
-  - coverage==7.2.1
+  - coverage<7.2.1
   - flake8==6.0.0
   - pytest==7.2.2
   - pytest-cov==4.0.0

--- a/continuous_integration/environment-3.10.yml
+++ b/continuous_integration/environment-3.10.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10.*
   - pip==23.0.1
   - wheel==0.38.4
-  - coverage<7.2.1
+  - coverage==7.2.1
   - flake8==6.0.0
   - pytest==7.2.2
   - pytest-cov==4.0.0

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,15 +33,15 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "Activate conda env"
+gpuci_logger "Update conda environment"
 . /opt/conda/etc/profile.d/conda.sh
+gpuci_mamba_retry update -n dask_image -f "$WORKSPACE/continuous_integration/environment-$PYTHON_VER.yml"
+
+gpuci_logger "Activate conda env"
 conda activate dask_image
 
 gpuci_logger "Install cupy"
 python -m pip install cupy-cuda112 -f https://pip.cupy.dev/pre
-
-# gpuci_logger "Install dask"
-# python -m pip install git+https://github.com/dask/dask
 
 gpuci_logger "Install dask-image"
 python setup.py install

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -35,7 +35,7 @@ nvidia-smi
 
 gpuci_logger "Update conda environment"
 . /opt/conda/etc/profile.d/conda.sh
-gpuci_mamba_retry update -n dask_image -f "$WORKSPACE/continuous_integration/environment-$PYTHON_VER.yml"
+gpuci_mamba_retry env update -n dask_image -f "$WORKSPACE/continuous_integration/environment-$PYTHON_VER.yml"
 
 gpuci_logger "Activate conda env"
 conda activate dask_image


### PR DESCRIPTION
Attempt to update the conda environment in the GPU CI images before running tests, which should hopefully allow us to capture environment changes like those made in #315 without needing to rebuild images.