### PR TITLE
ndmeasure.label: fix for arbitrary struct elements

### DIFF
--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -151,6 +151,10 @@ def label_adjacency_graph(labels, structure, nlabels):
         This matrix has value 1 at (i, j) if label i is connected to
         label j in the global volume, 0 everywhere else.
     """
+
+    if structure is None:
+        structure = scipy.ndimage.generate_binary_structure(labels.ndim, 1)
+
     faces = _chunk_faces(labels.chunks, labels.shape, structure)
     all_mappings = [da.empty((2, 0), dtype=LABEL_DTYPE, chunks=1)]
     for face_slice in faces:

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -337,6 +337,7 @@ def _assert_equivalent_labeling(labels0, labels1):
         (42, 0.4, (15, 16), (15, 16), 1),
         (42, 0.4, (15, 16), (4, 5), 1),
         (42, 0.4, (15, 16), (4, 5), 2),
+        (42, 0.4, (15, 16), (4, 5), None),
         (42, 0.4, (15, 16), (8, 5), 1),
         (42, 0.4, (15, 16), (8, 5), 2),
         (42, 0.3, (10, 8, 6), (5, 4, 3), 1),
@@ -350,7 +351,10 @@ def test_label(seed, prob, shape, chunks, connectivity):
     a = np.random.random(shape) < prob
     d = da.from_array(a, chunks=chunks)
 
-    s = scipy.ndimage.generate_binary_structure(a.ndim, connectivity)
+    if connectivity is None:
+        s = None
+    else:
+        s = scipy.ndimage.generate_binary_structure(a.ndim, connectivity)
 
     a_l, a_nl = scipy.ndimage.label(a, s)
     d_l, d_nl = dask_image.ndmeasure.label(d, s)


### PR DESCRIPTION
In https://github.com/dask/dask-image/issues/320 @vecxoz showed that the current implementation of `dask_image.ndmeasure.label` is not equivalent to `scipy.ndimage.label` when using a full structuring element. This PR fixes this.

Explanation:

`dask_image.ndmeasure.label` computes label maps for each block independently and then merges these by joining labels that are connected across block boundaries. However, it currently only considers orthogonal boundaries between chunks, which can lead to problems at diagonal chunk borders when using diagonal connectivity structuring elements.

Code changes:

In terms of implementation, `dask_image.ndmeasure.label` considers chunk boundaries by obtaining two-pixel wide slices that connect pairs of neighboring chunks using the function `dask_image.ndmeasure._utils._label._chunk_faces`. This function currently only returns these slices along orthogonal chunk boundaries. This PR extends this function such that the structuring element determines which boundaries are considered. Therefore, this implementation improves the equivalence between the `dask_image` and `scipy.ndimage` implementations while keeping the same dask graph structure for already supported structuring elements.

Tests:

This PR adds a test that documents the identified divergence between the two implementations and addresses the proposed improvement.

@jni and @jakirkham came up with the `dask_image.ndmeasure.label` implementation and could be great reviewers for this :)