### PR TITLE
Fix GitHub actions README badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ dask-image
         :target: https://anaconda.org/conda-forge/dask-image
         :alt: conda-forge
 
-.. image:: https://github.com/dask/dask-image/workflows/CI/badge.svg
-        :target: https://github.com/dask/dask-image/actions
+.. image:: https://github.com/dask/dask-image/actions/workflows/test_and_deploy.yml/badge.svg
+        :target: https://github.com/dask/dask-image/actions/workflows/test_and_deploy.yml
         :alt: GitHub Actions CI
 
 .. image:: https://readthedocs.org/projects/dask-image/badge/?version=latest


### PR DESCRIPTION
I noticed that the CI badge is saying failing, but the CI isn't failing - looks like it just needed updating to the current workflow name. See https://github.com/dstansby/dask-image/blob/patch-1/README.rst for the correctly rendered badge on this branch.