### PR TITLE
Moved functions from ndimage submodules to ndimage namespace

### DIFF
--- a/dask_image/dispatch/_dispatch_ndfilters.py
+++ b/dask_image/dispatch/_dispatch_ndfilters.py
@@ -56,7 +56,7 @@ def register_cupy_convolve():
 
     @dispatch_convolve.register(cupy.ndarray)
     def cupy_convolve(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.convolve
+        return cupyx.scipy.ndimage.convolve
 
 
 # ================== correlate ==================
@@ -72,7 +72,7 @@ def register_cupy_correlate():
 
     @dispatch_correlate.register(cupy.ndarray)
     def cupy_correlate(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.correlate
+        return cupyx.scipy.ndimage.correlate
 
 
 # ================== laplace ==================
@@ -88,7 +88,7 @@ def register_cupy_laplace():
 
     @dispatch_laplace.register(cupy.ndarray)
     def cupy_laplace(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.laplace
+        return cupyx.scipy.ndimage.laplace
 
 
 # ================== prewitt ==================
@@ -104,7 +104,7 @@ def register_cupy_prewitt():
 
     @dispatch_prewitt.register(cupy.ndarray)
     def cupy_prewitt(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.prewitt
+        return cupyx.scipy.ndimage.prewitt
 
 
 # ================== sobel ==================
@@ -120,7 +120,7 @@ def register_cupy_sobel():
 
     @dispatch_sobel.register(cupy.ndarray)
     def cupy_sobel(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.sobel
+        return cupyx.scipy.ndimage.sobel
 
 
 # ================== gaussian_filter ==================
@@ -136,7 +136,7 @@ def register_cupy_gaussian_filter():
 
     @dispatch_gaussian_filter.register(cupy.ndarray)
     def cupy_gaussian_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.gaussian_filter
+        return cupyx.scipy.ndimage.gaussian_filter
 
 
 # ================== gaussian_gradient_magnitude ==================
@@ -152,7 +152,7 @@ def register_cupy_gaussian_gradient_magnitude():
 
     @dispatch_gaussian_gradient_magnitude.register(cupy.ndarray)
     def cupy_gaussian_gradient_magnitude(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.gaussian_gradient_magnitude
+        return cupyx.scipy.ndimage.gaussian_gradient_magnitude
 
 
 # ================== gaussian_laplace ==================
@@ -168,7 +168,7 @@ def register_cupy_gaussian_laplace():
 
     @dispatch_gaussian_laplace.register(cupy.ndarray)
     def cupy_gaussian_laplace(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.gaussian_laplace
+        return cupyx.scipy.ndimage.gaussian_laplace
 
 
 # ================== generic_filter ==================
@@ -184,7 +184,7 @@ def register_cupy_generic_filter():
 
     @dispatch_generic_filter.register(cupy.ndarray)
     def cupy_generic_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.generic_filter
+        return cupyx.scipy.ndimage.generic_filter
 
 
 # ================== minimum_filter ==================
@@ -200,7 +200,7 @@ def register_cupy_minimum_filter():
 
     @dispatch_minimum_filter.register(cupy.ndarray)
     def cupy_minimum_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.minimum_filter
+        return cupyx.scipy.ndimage.minimum_filter
 
 
 # ================== median_filter ==================
@@ -216,7 +216,7 @@ def register_cupy_median_filter():
 
     @dispatch_median_filter.register(cupy.ndarray)
     def cupy_median_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.median_filter
+        return cupyx.scipy.ndimage.median_filter
 
 
 # ================== maximum_filter ==================
@@ -232,7 +232,7 @@ def register_cupy_maximum_filter():
 
     @dispatch_maximum_filter.register(cupy.ndarray)
     def cupy_maximum_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.maximum_filter
+        return cupyx.scipy.ndimage.maximum_filter
 
 
 # ================== rank_filter ==================
@@ -248,7 +248,7 @@ def register_cupy_rank_filter():
 
     @dispatch_rank_filter.register(cupy.ndarray)
     def cupy_rank_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.rank_filter
+        return cupyx.scipy.ndimage.rank_filter
 
 
 # ================== percentile_filter ==================
@@ -264,7 +264,7 @@ def register_cupy_percentile_filter():
 
     @dispatch_percentile_filter.register(cupy.ndarray)
     def cupy_percentile_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.percentile_filter
+        return cupyx.scipy.ndimage.percentile_filter
 
 
 # ================== uniform_filter ==================
@@ -280,7 +280,7 @@ def register_cupy_uniform_filter():
 
     @dispatch_uniform_filter.register(cupy.ndarray)
     def cupy_uniform_filter(*args, **kwargs):
-        return cupyx.scipy.ndimage.filters.uniform_filter
+        return cupyx.scipy.ndimage.uniform_filter
 
 
 # ================== threshold_local_mean ==================

--- a/tests/test_dask_image/test_imread/test_cupy_imread.py
+++ b/tests/test_dask_image/test_imread/test_cupy_imread.py
@@ -4,7 +4,7 @@ import pytest
 
 import dask_image.imread
 
-cupy = pytest.importorskip("cupy", minversion="7.7.0")
+cupy = pytest.importorskip("cupy", minversion="6.0.0")
 
 
 @pytest.mark.cupy

--- a/tests/test_dask_image/test_ndfilters/test_cupy_ndfilters.py
+++ b/tests/test_dask_image/test_ndfilters/test_cupy_ndfilters.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask_image.ndfilters
 
-cupy = pytest.importorskip("cupy", minversion="7.7.0")
+cupy = pytest.importorskip("cupy", minversion="8.0.0")
 
 
 @pytest.fixture

--- a/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
+++ b/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
@@ -7,7 +7,7 @@ import pytest
 
 from dask_image.ndfilters import threshold_local
 
-cupy = pytest.importorskip("cupy", minversion="7.7.0")
+cupy = pytest.importorskip("cupy", minversion="5.0.0")
 
 
 @pytest.mark.parametrize('block_size', [

--- a/tests/test_dask_image/test_ndfourier/test_core.py
+++ b/tests/test_dask_image/test_ndfourier/test_core.py
@@ -58,7 +58,7 @@ def test_fourier_filter_err(funcname, err_type, s, n):
 )
 def test_fourier_filter_identity(funcname, s):
     da_func = getattr(dask_image.ndfourier, funcname)
-    sp_func = getattr(scipy.ndimage.fourier, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
@@ -105,7 +105,7 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
     s = 1
 
     da_func = getattr(dask_image.ndfourier, funcname)
-    sp_func = getattr(scipy.ndimage.fourier, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))
@@ -147,7 +147,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
     s = 1
 
     da_func = getattr(dask_image.ndfourier, funcname)
-    sp_func = getattr(scipy.ndimage.fourier, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     a = np.arange(np.prod(shape)).reshape(shape).astype(dtype)
     d = da.from_array(a, chunks=chunks)
@@ -180,7 +180,7 @@ def test_fourier_filter_chunks(funcname, shape, chunks):
 )
 def test_fourier_filter_non_positive(funcname, s):
     da_func = getattr(dask_image.ndfourier, funcname)
-    sp_func = getattr(scipy.ndimage.fourier, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
@@ -225,7 +225,7 @@ def test_fourier_filter_non_positive(funcname, s):
 )
 def test_fourier_filter(funcname, s, real_fft, axis):
     da_func = getattr(dask_image.ndfourier, funcname)
-    sp_func = getattr(scipy.ndimage.fourier, funcname)
+    sp_func = getattr(scipy.ndimage, funcname)
 
     shape = (10, 14)
     n = 2 * shape[axis] - 1 if real_fft else -1

--- a/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
+++ b/tests/test_dask_image/test_ndinterp/test_affine_transformation.py
@@ -155,7 +155,7 @@ def test_affine_transform_cupy(n,
                                interp_order,
                                input_output_chunksize_per_dim,
                                random_seed):
-    pytest.importorskip("cupy", minversion="6.0.0")
+    pytest.importorskip("cupy", minversion="5.0.0")
 
     kwargs = dict()
     kwargs['n'] = n
@@ -264,7 +264,7 @@ def test_affine_transform_type_consistency():
 @pytest.mark.cupy
 def test_affine_transform_type_consistency_gpu():
 
-    cupy = pytest.importorskip("cupy", minversion="6.0.0")
+    cupy = pytest.importorskip("cupy", minversion="5.0.0")
 
     image = da.ones((3, 3))
     image_t = dask_image.ndinterp.affine_transform(image, np.eye(2), [0, 0])
@@ -314,7 +314,7 @@ def test_affine_transform_large_input_small_output_gpu():
     """
     Make sure input array does not need to be computed entirely
     """
-    cupy = pytest.importorskip("cupy", minversion="6.0.0")
+    cupy = pytest.importorskip("cupy", minversion="5.0.0")
 
     # this array would occupy more than 24GB on a GPU
     image = da.random.random([2000] * 3, chunks=(50, 50, 50))

--- a/tests/test_dask_image/test_ndinterp/test_spline_filter.py
+++ b/tests/test_dask_image/test_ndinterp/test_spline_filter.py
@@ -143,7 +143,7 @@ def test_spline_filter_cupy(
     input_as_non_dask_array,
 ):
 
-    pytest.importorskip("cupy", minversion="6.0.0")
+    pytest.importorskip("cupy", minversion="9.0.0")
 
     validate_spline_filter(
         n=n,

--- a/tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py
+++ b/tests/test_dask_image/test_ndmorph/test_cupy_ndmorph.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask_image.ndmorph
 
-cupy = pytest.importorskip("cupy", minversion="7.7.0")
+cupy = pytest.importorskip("cupy", minversion="9.0.0")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR moves functions from the `cupyx.scipy.ndimage.filters` namespace to `cupyx.scipy.ndimage`, fixing https://github.com/dask/dask-image/issues/324.

Secondly it changes a reference to `scipy.ndimage.fourier` into `scipy.ndimage` in test functions, anticipating the [removal](https://github.com/scipy/scipy/blob/2ff5a46ec3ecc86427e73801b7c6151ed29b6dea/scipy/ndimage/fourier.py#L1C1-L3C18) of `scipy.ndimage.fourier` in scipy version 2.