### PR TITLE
Added missing cupy test mark and fixed cupy threshold

### DIFF
--- a/dask_image/ndfilters/_threshold.py
+++ b/dask_image/ndfilters/_threshold.py
@@ -80,7 +80,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
                                                mode=mode, cval=cval)
     elif method == 'gaussian':
         if param is None:
-            sigma = (da.asarray(block_size, like=image._meta) - 1) / 6.0
+            sigma = (np.array(block_size).astype(float) - 1) / 6.0
         else:
             sigma = param
         thresh_image = _gaussian.gaussian_filter(image, sigma, mode=mode,

--- a/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
+++ b/tests/test_dask_image/test_ndfilters/test_cupy_threshold.py
@@ -10,6 +10,7 @@ from dask_image.ndfilters import threshold_local
 cupy = pytest.importorskip("cupy", minversion="5.0.0")
 
 
+@pytest.mark.cupy
 @pytest.mark.parametrize('block_size', [
     3,
     [3, 3],


### PR DESCRIPTION
This PR fixes https://github.com/dask/dask-image/issues/327 by
- adding the cupy mark to the ignored test
- passing `sigma` in `threshold_local` (gaussian mode) as a numpy array instead of as an array of the same type as the input image.

