### PR TITLE
Extended title underline in HISTORY.rst to fix twine error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@ History
 =======
 
 2023.08.0 (2023-08-03)
-------------------
+----------------------
 
 We're pleased to announce the release of dask-image 2023.08.0!
 


### PR DESCRIPTION
After creating release candidate 2023.08.0, github actions showed the following error when trying to upload to pypi:

<img width="527" alt="image" src="https://github.com/dask/dask-image/assets/12528388/77c05659-21db-4f36-ad72-04b1f54709b5">


Using `twine check dist/*` locally, I found the error was caused by the newly added title underline in HISTORY.rst being too short:
```rst
2023.08.0 (2023-08-03)
------------------
```
At first I was bit puzzled because I had copied this directly from the output of `generate_release_notes.py`, however previous release summaries in `HISTORY.rst` contained long enough title underlines.

Maybe it'd be a good addition to `generate_release_notes.py` to automatically adapt the title underline to the title determined by the version. Also, it could make sense to include the suggestion to `twine check dist/*` in the release guide.

Something else to mention here is that twine warns ```WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.```, which might be relevant for https://github.com/dask/dask-image/pull/306.

This PR corrects the title underline and will lead to a new release candidate.