### PR TITLE
Use `>=3.9` in `python_requires` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     cmdclass=cmdclasses,
     packages=setuptools.find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=requirements,
     license="BSD 3-Clause",
     zip_safe=False,


### PR DESCRIPTION
Follow up to PR ( https://github.com/dask/dask-image/pull/315 )

This is needed for `sdist`s & `whl`s to restrict Python version.