### PR TITLE
Increase minimum required python version in setup.py to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     cmdclass=cmdclasses,
     packages=setuptools.find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=requirements,
     license="BSD 3-Clause",
     zip_safe=False,


### PR DESCRIPTION
Since `dask-image` has dropped support for python 3.8 (https://github.com/dask/dask-image/pull/315), this PR increases the minimum required python version in `setup.py` to 3.9.

Good catch by @jakirkham, see [discussion here](https://github.com/conda-forge/dask-image-feedstock/pull/14#discussion_r1283655781).