### PR TITLE
Additions to release guide and change to release note generation script

### DIFF
--- a/docs/release/generate_release_notes.py
+++ b/docs/release/generate_release_notes.py
@@ -163,8 +163,8 @@ highlights['Other Pull Requests'] = other_pull_requests
 
 
 # Now generate the release notes
-title = (f'{args.version} ({datetime.today().strftime("%Y-%m-%d")})'
-         '\n------------------')
+title = (f'{args.version} ({datetime.today().strftime("%Y-%m-%d")})')
+title += f'\n' + f'-' * len(title) #title underline of same length as title
 print(title)
 
 print(

--- a/docs/release/release_guide.rst
+++ b/docs/release/release_guide.rst
@@ -55,7 +55,7 @@ Generate the release notes
 
 The release notes contain a list of merges, contributors, and reviewers.
 
-1. Crate a GH_TOKEN environment variable on your computer.
+1. Create a GH_TOKEN environment variable on your computer.
 
     On Linux/Mac:
 
@@ -120,9 +120,10 @@ Go to the dask-image releases page: https://github.com/dask/dask-image/releases
 
 Click the "Draft Release" button to create a new release candidate.
 
-- Both the tag version and release title should have the format ``vYYYY.MM.DDrc1``.
+- Both the tag version and release title should have the format ``vYYYY.MM.Xrc1``.
 - Copy-paste the release notes from ``HISTORY.rst`` for this release into the
   description text box.
+- Tick "Set as a pre-release"
 
 Note here how we are using ``rc`` for release candidate to create a version
 of our release we can test before making the real release.
@@ -146,7 +147,7 @@ in order to isolate dependencies.
 
 If the release candidate is not what you want, make your changes and
 repeat the process from the beginning but
-incrementing the number after ``rc`` (e.g. ``vYYYY.MM.DDrc1``).
+incrementing the number after ``rc`` (e.g. ``vYYYY.MM.Xrc1``).
 
 Once you are satisfied with the release candidate it is time to generate
 the actual release.
@@ -155,7 +156,9 @@ Generating the actual release
 -----------------------------
 
 To generate the actual release you will now repeat the processes above
-but now dropping the ``rc`` suffix from the version number.
+but now
+- dropping the ``rc`` suffix from the version number.
+- ticking "Set as the latest release"
 
 This will automatically upload the release to PyPI, and will also
 automatically begin the process to release the new version on conda-forge.
@@ -171,10 +174,17 @@ conda-forge feedstock here: https://github.com/conda-forge/dask-image-feedstock
 Note: the conda-forge bot will not open a PR for any of the release candidates,
 only for the final release. Only one PR is opened for
 
+As an alternative to waiting for the conda-forge bot to notice the new release,
+you can submit a new dask-image feedstock issue indicating
+``@conda-forge-admin, please update version`` in the issue title. This will
+`trigger <https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-update-version>`_`
+the bot to check for new versions.
+
 Before merging the pull request, first you should check:
 
 * That all the tests have passed on CI for this pull request
-* If any dependencies were changed, and should be updated in the pull request
+* If any dependencies were changed, and should be updated by
+  commiting changes to ``recipe/meta.yaml`` to the pull request
 
 Once that all looks good you can merge the pull request,
 and the newest version of ``dask-image`` will automatically be made


### PR DESCRIPTION
While creating the 2023.08.0 release (https://github.com/dask/dask-image/issues/330) I could test the fantastic release guide by @GenevieveBuckley and found it super useful. Basically everything worked as described (there was some trouble during the release but unrelated to the release notes).

I didn't find that any particular step could be much simpler, but I completely agree that there's potential for automatization as discussed in https://github.com/dask/dask-image/issues/331.

One little problem that I encountered was that after copying the release notes generated by `generate_release_notes.py` to `HISTORY.rst` and creating a release (candidate), twine complained about invalid restructured text. It turned out to be a too short title underline https://github.com/dask/dask-image/pull/334.

So in this PR I'm
1) adding minor changes to the release guide and
2) modifying the relevant part of `generate_release_notes.py` to produce rst compatible title underlines.

Of course, this might not be very important or at least very transitory in the light of migrating to a more automated release process.