### PR TITLE
Workaround for the sphinx version problem in the readthedocs build environment

### DIFF
--- a/continuous_integration/environment-doc.yml
+++ b/continuous_integration/environment-doc.yml
@@ -7,7 +7,6 @@ dependencies:
   - python=3.9.*
   - pip==22.3
   - wheel==0.37.1
-  - sphinx==5.3.0
   - jinja2<3.1
   - dask==2023.2.0
   - numpy==1.23.4
@@ -17,4 +16,14 @@ dependencies:
   - slicerator==1.1.0
   - pandas==2.0.0
   - pip:
-      - dask-sphinx-theme>=3.0.0
+    - sphinx>=4.0.0
+    - dask-sphinx-theme>=3.0.0
+    # FIXME: This workaround is required until we have sphinx>=5, as enabled by
+    #        dask-sphinx-theme no longer pinning sphinx-book-theme==0.2.0. This is
+    #        tracked in https://github.com/dask/dask-sphinx-theme/issues/68.
+    #        Once sphinx>=5 is available, we can remove this workaround.
+    - sphinxcontrib-applehelp>=1.0.0,<1.0.7
+    - sphinxcontrib-devhelp>=1.0.0,<1.0.6
+    - sphinxcontrib-htmlhelp>=2.0.0,<2.0.5
+    - sphinxcontrib-serializinghtml>=1.1.0,<1.1.10
+    - sphinxcontrib-qthelp>=1.0.0,<1.0.7

--- a/continuous_integration/environment-doc.yml
+++ b/continuous_integration/environment-doc.yml
@@ -16,12 +16,12 @@ dependencies:
   - slicerator==1.1.0
   - pandas==2.0.0
   - pip:
-    - sphinx>=4.0.0
-    - dask-sphinx-theme>=3.0.0
     # FIXME: This workaround is required until we have sphinx>=5, as enabled by
     #        dask-sphinx-theme no longer pinning sphinx-book-theme==0.2.0. This is
     #        tracked in https://github.com/dask/dask-sphinx-theme/issues/68.
     #        Once sphinx>=5 is available, we can remove this workaround.
+    - dask-sphinx-theme>=3.0.0
+    - sphinx>=4.0.0
     - sphinxcontrib-applehelp>=1.0.0,<1.0.7
     - sphinxcontrib-devhelp>=1.0.0,<1.0.6
     - sphinxcontrib-htmlhelp>=2.0.0,<2.0.5


### PR DESCRIPTION
This PR addresses https://github.com/dask/dask-image/issues/351 by implementing https://github.com/dask/dask-sphinx-theme/issues/68#issuecomment-1893198477.

Further discussions here https://github.com/readthedocs/readthedocs.org/issues/11140.