### PR TITLE
Relaxed type check of input array, to allow da.core.Array sub-classes…

### DIFF
--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -83,7 +83,7 @@ def affine_transform(
 
     """
 
-    if not type(image) == da.core.Array:
+    if not isinstance(image, da.core.Array):
         image = da.from_array(image)
 
     if output_shape is None:
@@ -328,7 +328,7 @@ def rotate(
     (724, 724)
 
     """
-    if not type(input_arr) == da.core.Array:
+    if not isinstance(input_arr, da.core.Array):
         input_arr = da.from_array(input_arr)
 
     if output_chunks is None:
@@ -434,7 +434,7 @@ def spline_filter(
         **kwargs
 ):
 
-    if not type(image) == da.core.Array:
+    if not isinstance(image, da.core.Array):
         image = da.from_array(image)
 
     # use dispatching mechanism to determine backend
@@ -492,7 +492,7 @@ def spline_filter1d(
         **kwargs
 ):
 
-    if not type(image) == da.core.Array:
+    if not isinstance(image, da.core.Array):
         image = da.from_array(image)
 
     # use dispatching mechanism to determine backend


### PR DESCRIPTION
For some file formats [aicsimageio](https://github.com/AllenCellModeling/aicsimageio) and [nd2](https://github.com/tlambert03/nd2/issues) return a sub-class of `da.core.Array`: [ResourceBackedDaskAray](https://github.com/tlambert03/resource-backed-dask-array)

This PR relaxes the input type check to allow da.core.Array sub-classes in ndinterp functions.

Closes #360
