### PR TITLE
Pin dask to 2024.4.1 to avoid error during dask.dataframe import with python 3.11.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "dask[array] >=2023.2.0",
-    "dask[dataframe] >=2023.2.0",
+    "dask[array] >=2024.4.1",
+    "dask[dataframe] >=2024.4.1",
     "numpy >=1.18",
     "scipy >=1.7.0",
     "pims >=0.4.1",


### PR DESCRIPTION
Fixes https://github.com/dask/dask-image/issues/362, see https://github.com/dask/dask/pull/11035.