### PR TITLE
Update CI test environments

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      # fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11"]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      # fail-fast: true
+      fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11"]

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11"]

--- a/continuous_integration/environment-3.10.yml
+++ b/continuous_integration/environment-3.10.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest==7.2.2
   - pytest-cov==4.0.0
   - pytest-flake8==1.1.1
-  - dask==2023.3.1
+  - dask==2024.4.1
   - numpy==1.24.2
   - scipy==1.10.1
   - scikit-image==0.19.3

--- a/continuous_integration/environment-3.11.yml
+++ b/continuous_integration/environment-3.11.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest==7.2.2
   - pytest-cov==4.0.0
   - pytest-flake8==1.1.1
-  - dask==2023.3.1
+  - dask==2024.4.1
   - numpy==1.24.2
   - scipy==1.10.1
   - scikit-image==0.19.3

--- a/continuous_integration/environment-3.9.yml
+++ b/continuous_integration/environment-3.9.yml
@@ -12,7 +12,7 @@ dependencies:
   - pytest==6.2.5
   - pytest-cov==4.0.0
   - pytest-flake8==1.0.7
-  - dask==2023.2.1
+  - dask==2024.4.1
   - numpy==1.22.1
   - scipy==1.7.3
   - scikit-image==0.19.1

--- a/continuous_integration/environment-3.9.yml
+++ b/continuous_integration/environment-3.9.yml
@@ -5,17 +5,17 @@ channels:
 
 dependencies:
   - python=3.9.*
-  - pip==22.0.2
-  - wheel==0.37.1
-  - coverage==6.3
-  - flake8==4.0.1
-  - pytest==6.2.5
-  - pytest-cov==4.0.0
-  - pytest-flake8==1.0.7
+  - pip==24.0
+  - wheel==0.43.0
+  - coverage==7.5.1
+  - flake8==7.0.0
+  - pytest==8.2.0
+  - pytest-cov==5.0.0
+  - pytest-flake8==1.1.1
   - dask==2024.4.1
-  - numpy==1.22.1
-  - scipy==1.7.3
-  - scikit-image==0.19.1
-  - pims==0.5
-  - slicerator==1.0.0
-  - pandas==2.0.0
+  - numpy==1.26.4
+  - scipy==1.13.0
+  - scikit-image==0.22.0
+  - pims==0.6.1
+  - slicerator==1.1.0
+  - pandas==2.2.2

--- a/continuous_integration/environment-doc.yml
+++ b/continuous_integration/environment-doc.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip==22.3
   - wheel==0.37.1
   - jinja2<3.1
-  - dask==2023.2.0
+  - dask==2024.4.1
   - numpy==1.23.4
   - scipy==1.9.2
   - scikit-image==0.19.3


### PR DESCRIPTION
This PR:
* Updates the python 3.9 CI test environment, with a configuration I've checked works on arm64 Mac.
* Updates all of the environment yaml files to use dask==2024.4.1 (see https://github.com/dask/dask-image/pull/363)

I didn't think we needed to do this, since all of the CI checks for https://github.com/dask/dask-image/pull/363 passed before we merged it, but manually triggering CI on the main branch is failing ([see here](https://github.com/dask/dask-image/actions/runs/9074896375)). So this is an attempt to fix that problem.


