### PR TITLE
Update minimum versions in `dependencies`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,9 @@ classifiers = [
 dependencies = [
     "dask[array,dataframe] >=2024.4.1",
     "numpy >=1.18",
-    "scikit-image >=0.19.3",
     "scipy >=1.7.0",
     "pandas >=2.0.0",
     "pims >=0.4.1",
-    "slicerator >=1.1.0",
     "tifffile >=2018.10.18",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "scipy >=1.7.0",
     "pandas >=2.0.0",
     "pims >=0.4.1",
-    "slicerator >= 1.1.0",
+    "slicerator >=1.1.0",
     "tifffile >=2018.10.18",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [
 ]
 dependencies = [
     "dask[array,dataframe] >=2024.4.1",
-    "numpy >=1.11.3",
+    "numpy >=1.18",
     "scikit-image >=0.19.3",
-    "scipy >=0.19.1",
+    "scipy >=1.7.0",
     "pandas >=2.0.0",
     "pims >=0.4.1",
     "slicerator >= 1.1.0",


### PR DESCRIPTION
It looks like a few dependencies had higher minimum versions when using `setup.py`

https://github.com/dask/dask-image/blob/243fb0a5de55f5bc5b8650985d26381a7c22889e/setup.py#L31-L39

Though we wound up with older versions after switching to `pyproject.toml`

https://github.com/dask/dask-image/blob/49d9c336bc4551bbfc89c7d3527b0c176ae6f4a5/pyproject.toml#L26-L35

Guessing this is just because the `pyproject.toml` PR has fallen out of date in this area and we missed it

So went ahead and bumped these. Though please let me know if I'm missing something