### PR TITLE
Install dask-image with `pip` on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,3 +10,8 @@ sphinx:
 
 conda:
   environment: continuous_integration/environment-doc.yml
+
+python:
+  install:
+    - method: pip
+      path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ gpu = [
 "Source Code" = "https://github.com/dask/dask-image"
 
 [tool.setuptools_scm]
+version_scheme = "no-guess-dev"
 version_file = "dask_image/_version.py"
 
 [tool.setuptools]


### PR DESCRIPTION
* Install on RTD with `pip` (keeps the git repo clean, which likely causes the ".dev0" version issue)
* Disable `setuptools-scm`'s `version_scheme` guess (states versions in terms of distance passed the old version)