### PR TITLE
Have `git` ignore some RTD changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    pre_install:
+      # Avoid `git` treating the directory is dirty due to RTD changes.
+      # ref: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
+      - git update-index --assume-unchanged environment.yml docs/conf.py
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,10 @@ build:
     pre_install:
       # Avoid `git` treating the directory is dirty due to RTD changes.
       # ref: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
-      - > git update-index --assume-unchanged
-          continuous_integration/environment-doc.yml
-          docs/conf.py
+      - >-
+        git update-index --assume-unchanged
+        continuous_integration/environment-doc.yml
+        docs/conf.py
       # If we missed any, error and list the changed files.
       - git diff --stat --exit-code
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-22.04"
   tools:
     python: "mambaforge-4.10"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,9 @@ build:
     pre_install:
       # Avoid `git` treating the directory is dirty due to RTD changes.
       # ref: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
-      - git update-index --assume-unchanged continuous_integration/environment-doc.yml docs/conf.py
+      - > git update-index --assume-unchanged
+          continuous_integration/environment-doc.yml
+          docs/conf.py
       # If we missed any, error and list the changed files.
       - git diff --stat --exit-code
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
     pre_install:
       # Avoid `git` treating the directory is dirty due to RTD changes.
       # ref: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
-      - git update-index --assume-unchanged environment.yml docs/conf.py
+      - git update-index --assume-unchanged continuous_integration/environment-doc.yml docs/conf.py
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ build:
       # Avoid `git` treating the directory is dirty due to RTD changes.
       # ref: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
       - git update-index --assume-unchanged continuous_integration/environment-doc.yml docs/conf.py
+      - git status
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,8 @@ build:
       # Avoid `git` treating the directory is dirty due to RTD changes.
       # ref: https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index
       - git update-index --assume-unchanged continuous_integration/environment-doc.yml docs/conf.py
-      - git status
+      # If we missed any, error and list the changed files.
+      - git diff --stat --exit-code
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Based on [this recommendation from RTD]( https://docs.readthedocs.io/en/stable/build-customization.html#avoid-having-a-dirty-git-index ), ask `git` to ignore some changes RTD makes. Hopefully should fix `setuptools-scm` issues we have seen ( https://github.com/dask/dask-image/issues/375 )