### PR TITLE
ReadTheDocs: fix displayed version number in top left corner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,11 +130,11 @@ html_theme = 'dask_sphinx_theme'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = f"{project} {version} documentation"
 
 # A shorter title for the navigation bar.  Default is the same as
 # html_title.
-#html_short_title = None
+html_short_title = f"{project} docs"
 
 # The name of an image file (relative to this directory) to place at the
 # top of the sidebar.


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/375

Fix problem where RTD displays full release version string (eg: X.Y.Z.dev0+gXXXXXX)., not shorter X.Y.Z version

![](https://private-user-images.githubusercontent.com/6197628/331556569-4993916c-bcc9-4f5d-9013-9e1ff40aa90e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTYyNzk5MDksIm5iZiI6MTcxNjI3OTYwOSwicGF0aCI6Ii82MTk3NjI4LzMzMTU1NjU2OS00OTkzOTE2Yy1iY2M5LTRmNWQtOTAxMy05ZTFmZjQwYWE5MGUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDUyMSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA1MjFUMDgyMDA5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YTI4OGM1MzQ3ZmVhODcyMjUzNjE1NzE4YWVmYTEzMmZkZjA3NTIzNTI5MDY4NTI4OTAwZWNiMDZmZjllNTQ3YSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.to_46wZ9zSmRP3ZWSNINU5XYUblkH3e7ZGAPdR2Z8qo)