### PR TITLE
Update conf.py, sphinx context injection deprecated in ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,9 +123,10 @@ exclude_patterns = ['_build']
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
-html_context = {}
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
     html_context["READTHEDOCS"] = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,13 @@ exclude_patterns = ['_build']
 
 # -- Options for HTML output -------------------------------------------
 
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'dask_sphinx_theme'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,7 @@ exclude_patterns = ['_build']
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
+html_context = {}
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":
     html_context["READTHEDOCS"] = True


### PR DESCRIPTION
Closes https://github.com/dask/dask-image/issues/382

ReadTheDocs is deprecating sphinx context injection. We need to set the canonical url a different way.
