### PR TITLE
Fix CI test failures

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
-          use-mamba: true
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment-${{ matrix.python-version }}.yml
           activate-environment: dask-image-testenv

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -370,7 +370,7 @@ def rotate(
         out_bounds = rot_matrix @ [[0, 0, iy, iy],
                                    [0, ix, 0, ix]]
         # Compute the shape of the transformed input plane
-        out_plane_shape = (out_bounds.ptp(axis=1) + 0.5).astype(int)
+        out_plane_shape = (np.ptp(out_bounds, axis=1) + 0.5).astype(int)
     else:
         out_plane_shape = img_shape[axes]
 

--- a/dask_image/ndinterp/__init__.py
+++ b/dask_image/ndinterp/__init__.py
@@ -367,8 +367,9 @@ def rotate(
     if reshape:
         # Compute transformed input bounds
         iy, ix = in_plane_shape
-        out_bounds = rot_matrix @ [[0, 0, iy, iy],
-                                   [0, ix, 0, ix]]
+        in_bounds = np.array([[0, 0, iy, iy],
+                              [0, ix, 0, ix]])
+        out_bounds = rot_matrix @ in_bounds
         # Compute the shape of the transformed input plane
         out_plane_shape = (np.ptp(out_bounds, axis=1) + 0.5).astype(int)
     else:

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -5,6 +5,7 @@ import functools
 import operator
 import warnings
 from dask import compute, delayed
+import dask.config as dask_config
 
 import dask.array as da
 import dask.bag as db
@@ -244,7 +245,9 @@ def find_objects(label_image):
     result = bag.fold(functools.partial(_find_objects, label_image.ndim), split_every=2).to_delayed()
     meta = dd.utils.make_meta([(i, object) for i in range(label_image.ndim)])
     result = delayed(compute)(result)[0]  # avoid the user having to call compute twice on result
-    result = dd.from_delayed(result, meta=meta, prefix="find-objects-", verify_meta=False)
+
+    with dask_config.set({'dataframe.convert-string': False}):
+        result = dd.from_delayed(result, meta=meta, prefix="find-objects-", verify_meta=False)
 
     return result
 

--- a/dask_image/ndmeasure/_utils/_find_objects.py
+++ b/dask_image/ndmeasure/_utils/_find_objects.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from dask.delayed import Delayed
 import dask.dataframe as dd
+import dask.config as dask_config
 
 
 def _array_chunk_location(block_id, chunks):
@@ -67,9 +68,11 @@ def _find_objects(ndim, df1, df2):
     """Main utility function for find_objects."""
     meta = dd.utils.make_meta([(i, object) for i in range(ndim)])
     if isinstance(df1, Delayed):
-        df1 = dd.from_delayed(df1, meta=meta)
+        with dask_config.set({'dataframe.convert-string': False}):
+            df1 = dd.from_delayed(df1, meta=meta)
     if isinstance(df2, Delayed):
-        df2 = dd.from_delayed(df2, meta=meta)
+        with dask_config.set({'dataframe.convert-string': False}):
+            df2 = dd.from_delayed(df2, meta=meta)
     ddf = dd.merge(df1, df2, how="outer", left_index=True, right_index=True)
     result = ddf.apply(_merge_bounding_boxes, ndim=ndim, axis=1, meta=meta)
     return result

--- a/tests/test_dask_image/test_imread/test_core.py
+++ b/tests/test_dask_image/test_imread/test_core.py
@@ -76,7 +76,8 @@ def test_tiff_imread(tmpdir, seed, nframes, shape, dtype, is_pathlib_Path):  # n
     fn = str(dirpth.join("test.tiff"))
     with tifffile.TiffWriter(fn) as fh:
         for i in range(len(a)):
-            fh.save(a[i], contiguous=True)
+            fh.write(a[i], contiguous=True)
+
     if is_pathlib_Path:
         fn = pathlib.Path(fn)
     d = dask_image.imread.imread(fn, nframes=nframes)


### PR DESCRIPTION
With this PR I started out just wanting to ensure compatibility with numpy 2 as reported in https://github.com/dask/dask-image/issues/392, however different issues came up in the tests (and if unaddressed they make the CI fail), so I decided to address them together in the same PR.

Summary:

1) Use `np.ptp` instead of the method to ensure compatibility with numpy 2 as reported in https://github.com/dask/dask-image/issues/392.

2) Replace the deprecated `tifffile.TiffWriter.save` by `tifffile.TiffWriter.save`, see [here](https://github.com/cgohlke/tifffile/blame/f1d053c1f9922a207b84df615eefa52c6fbae3bb/tifffile/tifffile.py#L122C7-L122C7).

3) `dask-image` currently doesn't pass tests with `dask>=2025.1.0` because of https://github.com/dask/dask-image/issues/335 which came back because of changes in `dask.dataframe` (more details [here](https://github.com/dask/dask-image/issues/335#issuecomment-2678690320)). This PR applies the proposed workaround. An alternative would be to pin `dask<2025.1.0`, but probably a very limiting option.

4) (edit) Stop using Mambaforge in the CI. According to https://github.com/conda-forge/miniforge mambaforge is deprecated since 2024 and installers have been retired in 2025.

@jakirkham @GenevieveBuckley 