### PR TITLE
Use `tifffile.TiffWriter`'s `write` method in `test_cupy_imread`

### DIFF
--- a/tests/test_dask_image/test_imread/test_cupy_imread.py
+++ b/tests/test_dask_image/test_imread/test_cupy_imread.py
@@ -14,7 +14,7 @@ def test_cupy_imread(tmp_path):
     fn = str(tmp_path/"test.tiff")
     with tifffile.TiffWriter(fn) as fh:
         for i in range(len(a)):
-            fh.save(a[i])
+            fh.write(a[i])
 
     result = dask_image.imread.imread(fn, arraytype="cupy")
     assert type(result._meta) == cupy.ndarray


### PR DESCRIPTION
Fixes https://github.com/dask/dask-image/issues/397

Recently [`tifffile` removed the `save` method]( https://github.com/cgohlke/tifffile/blob/78b57cf84bd92528ba8877ea4972769bb4d43600/tifffile/tifffile.py#L132 ), which has been deprecated. Switch to the `write` method to fix it.