### PR TITLE
Add label merging function (and improve ndmeasure.label)

### DIFF
--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -360,8 +360,9 @@ def label(
         - (0, 1) wrap across the 0th and 1st axis.
         - (0, 1, 3)  wrap across 0th, 1st and 3rd axis.
     produce_sequential_labels : bool, optional
-        If False, the returned labels are not contiguous (i.e. 0, 1, 6045, 54654).
-        This is the default behavior and has advantages for parallelism.
+        If False, the returned labels are not contiguous
+        (i.e. 0, 1, 6045, 54654). This is the default behavior
+        and has advantages for parallelism.
         If True, the labels are relabeled to be sequential
         and contiguous from 1 to the number of features.
 
@@ -388,20 +389,21 @@ def label(
         wrap_axes=wrap_axes,
         produce_sequential_labels=False,
         )
-    
+
     relabeled = merged_labels_dict['labels']
     mapping = merged_labels_dict['mapping']
 
     if produce_sequential_labels:
         relabeled = relabel_sequential(relabeled)
         n = relabeled.max()
-        
+
     else:
         def count_labels(label_block):
             return len(np.unique(label_block[label_block > 0]))
 
         total = block_labeled.map_blocks(
-            lambda x: np.ones((1, ) * x.ndim, dtype=np.uint64) * count_labels(x),
+            lambda x: np.ones(
+                (1, ) * x.ndim, dtype=np.uint64) * count_labels(x),
             dtype=np.uint64,
             chunks=(1, ) * block_labeled.ndim
         ).sum()
@@ -432,7 +434,8 @@ def merge_labels_across_chunk_boundaries(
     chunk boundaries using a strategy dependent on ``overlap``:
     - If ``overlap > 0``, the overlap region between chunks is used to
       determine which between each pair of chunks should be merged.
-    - If ``overlap == 0``, labels that touch across chunk boundaries are merged.
+    - If ``overlap == 0``, labels that touch across chunk boundaries
+    are merged.
 
     Parameters
     ----------
@@ -444,8 +447,8 @@ def merge_labels_across_chunk_boundaries(
     iou_threshold : float, optional
         If ``overlap > 0``, the intersection-over-union (IoU) between labels
         in the overlap region is used to determine which labels should be
-        merged. If the IoU between two labels is greater than ``iou_threshold``,
-        they are merged. Default is 0.8.
+        merged. If the IoU between two labels is greater than
+        ``iou_threshold``, they are merged. Default is 0.8.
     structure : array of bool, optional
         Structuring element for determining connectivity. If None, a
         cross-shaped structuring element is used.
@@ -468,9 +471,9 @@ def merge_labels_across_chunk_boundaries(
             A mapping from old labels to new labels.
     """
 
-    # Make labels unique across blocks by encoding the block ID into the labels.
-    # We use half the bits to encode the block ID and half the bits to encode
-    # the label ID within the block.
+    # Make labels unique across blocks by encoding the block ID into
+    # the labels. We use half the bits to encode the block ID and half the
+    # bits to encode the label ID within the block.
     block_labeled_unique = _label._make_labels_unique(
         labels, encoding_dtype=np.uint32)
 
@@ -518,7 +521,8 @@ def relabel_sequential(labels):
             [da.unique(b) for b in labels.blocks]
             )
         )
-    mapping = delayed(lambda x: {k: v for k, v in zip(x, np.arange(len(x)))})(u)
+    mapping = delayed(
+        lambda x: {k: v for k, v in zip(x, np.arange(len(x)))})(u)
 
     relabeled = _label.relabel(labels, mapping)
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -393,13 +393,7 @@ def label(
     all_mappings = _label.label_adjacency_mapping(
         block_labeled_unique, structure, wrap_axes=wrap_axes
     )
-    mapping, n_red = _label.connected_components_delayed(all_mappings)
-
-    n_red = da.from_delayed(
-        n_red,
-        shape=(),
-        dtype=np.uint16
-    )
+    mapping = _label.connected_components_delayed(all_mappings)
 
     relabeled = _label.relabel_blocks(
         block_labeled_unique, mapping
@@ -421,7 +415,11 @@ def label(
             chunks=(1, ) * block_labeled.ndim
         ).sum()
 
-        n = total - n_red
+        n = total - da.from_delayed(
+            delayed(_label.count_n_of_collapsed_labels)(mapping),
+            shape=(),
+            dtype=np.uint64
+        )
 
     return (relabeled, n)
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -402,17 +402,19 @@ def label(
             return len(np.unique(label_block[label_block > 0]))
 
         total = block_labeled.map_blocks(
-            lambda x: np.ones(
-                (1, ) * x.ndim, dtype=np.uint64) * count_labels(x),
+            lambda x: (np.ones(
+                (1, ) * x.ndim) * count_labels(x)).astype(np.uint64),
             dtype=np.uint64,
             chunks=(1, ) * block_labeled.ndim
         ).sum()
 
-        n = total - da.from_delayed(
+        n_reduced = da.from_delayed(
             delayed(_label.count_n_of_collapsed_labels)(mapping),
             shape=(),
             dtype=np.uint64
         )
+
+        n = total - n_reduced
 
     return (relabeled, n)
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -10,6 +10,7 @@ import dask.config as dask_config
 import dask.array as da
 import dask.bag as db
 import numpy as np
+from scipy.ndimage import label as ndimage_label
 
 from . import _utils
 from ._utils import _label
@@ -326,7 +327,12 @@ def histogram(image,
     return result
 
 
-def label(image, structure=None, wrap_axes=None):
+def label(
+        image,
+        structure=None,
+        wrap_axes=None,
+        produce_sequential_labels=False,
+        ):
     """
     Label features in an array.
 
@@ -345,7 +351,6 @@ def label(image, structure=None, wrap_axes=None):
             [[0,1,0],
              [1,1,1],
              [0,1,0]]
-
     wrap_axes : tuple of int, optional
         Whether labels should be wrapped across array boundaries, and if so
         which axes.
@@ -354,6 +359,11 @@ def label(image, structure=None, wrap_axes=None):
         - (0,) only wrap across the 0th axis.
         - (0, 1) wrap across the 0th and 1st axis.
         - (0, 1, 3)  wrap across 0th, 1st and 3rd axis.
+    produce_sequential_labels : bool, optional
+        If False, the returned labels are not contiguous (i.e. 0, 1, 6045, 54654).
+        This is the default behavior and has advantages for parallelism.
+        If True, the labels are relabeled to be sequential
+        and contiguous from 1 to the number of features.
 
     Returns
     -------
@@ -366,41 +376,52 @@ def label(image, structure=None, wrap_axes=None):
 
     image = da.asarray(image)
 
-    labeled_blocks = np.empty(image.numblocks, dtype=object)
-
-    # First, label each block independently, incrementing the labels in that
-    # block by the total number of labels from previous blocks. This way, each
-    # block's labels are globally unique.
-    block_iter = zip(
-        np.ndindex(*image.numblocks),
-        map(functools.partial(operator.getitem, image),
-            da.core.slices_from_chunks(image.chunks))
+    block_labeled = image.map_blocks(
+        lambda x: ndimage_label(x, structure=structure)[0],
+        dtype=_label.LABEL_DTYPE,
     )
-    index, input_block = next(block_iter)
-    labeled_blocks[index], total = _label.block_ndi_label_delayed(input_block,
-                                                                  structure)
-    for index, input_block in block_iter:
-        labeled_block, n = _label.block_ndi_label_delayed(input_block,
-                                                          structure)
-        block_label_offset = da.where(labeled_block > 0,
-                                      total,
-                                      _label.LABEL_DTYPE.type(0))
-        labeled_block += block_label_offset
-        labeled_blocks[index] = labeled_block
-        total += n
 
-    # Put all the blocks together
-    block_labeled = da.block(labeled_blocks.tolist())
+    # Make labels unique across blocks by encoding the block ID into the labels.
+    # We use half the bits to encode the block ID and half the bits to encode
+    # the label ID within the block.
+    block_labeled_unique = _label._make_labels_unique(
+        block_labeled, encoding_dtype=np.uint32)
 
-    # Now, build a label connectivity graph that groups labels across blocks.
-    # We use this graph to find connected components and then relabel each
+    # Now, build a label mapping that groups labels across blocks.
+    # We use this mapping to find connected components and then relabel each
     # block according to those.
-    label_groups = _label.label_adjacency_graph(
-        block_labeled, structure, total, wrap_axes=wrap_axes
+    all_mappings = _label.label_adjacency_mapping(
+        block_labeled_unique, structure, wrap_axes=wrap_axes
     )
-    new_labeling = _label.connected_components_delayed(label_groups)
-    relabeled = _label.relabel_blocks(block_labeled, new_labeling)
-    n = da.max(relabeled)
+    mapping, n_red = _label.connected_components_delayed(all_mappings)
+
+    n_red = da.from_delayed(
+        n_red,
+        shape=(),
+        dtype=np.uint16
+    )
+
+    relabeled = _label.relabel_blocks(
+        block_labeled_unique, mapping
+    )
+
+    relabeled = relabeled.astype(_label.LABEL_DTYPE)
+
+    if produce_sequential_labels:
+        relabeled = _label.relabel_sequential(relabeled)
+        n = relabeled.max()
+        
+    else:
+        def count_labels(label_block):
+            return len(np.unique(label_block[label_block > 0]))
+
+        total = block_labeled.map_blocks(
+            lambda x: np.ones((1, ) * x.ndim, dtype=np.uint64) * count_labels(x),
+            dtype=np.uint64,
+            chunks=(1, ) * block_labeled.ndim
+        ).sum()
+
+        n = total - n_red
 
     return (relabeled, n)
 

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import collections
 import functools
 import operator
+import collections
 import warnings
 from dask import compute, delayed
 import dask.config as dask_config
@@ -381,28 +381,19 @@ def label(
         dtype=_label.LABEL_DTYPE,
     )
 
-    # Make labels unique across blocks by encoding the block ID into the labels.
-    # We use half the bits to encode the block ID and half the bits to encode
-    # the label ID within the block.
-    block_labeled_unique = _label._make_labels_unique(
-        block_labeled, encoding_dtype=np.uint32)
-
-    # Now, build a label mapping that groups labels across blocks.
-    # We use this mapping to find connected components and then relabel each
-    # block according to those.
-    all_mappings = _label.label_adjacency_mapping(
-        block_labeled_unique, structure, wrap_axes=wrap_axes
-    )
-    mapping = _label.connected_components_delayed(all_mappings)
-
-    relabeled = _label.relabel_blocks(
-        block_labeled_unique, mapping
-    )
-
-    relabeled = relabeled.astype(_label.LABEL_DTYPE)
+    merged_labels_dict = merge_labels_across_chunk_boundaries(
+        block_labeled,
+        overlap_depth=0,
+        structure=structure,
+        wrap_axes=wrap_axes,
+        produce_sequential_labels=False,
+        )
+    
+    relabeled = merged_labels_dict['labels']
+    mapping = merged_labels_dict['mapping']
 
     if produce_sequential_labels:
-        relabeled = _label.relabel_sequential(relabeled)
+        relabeled = relabel_sequential(relabeled)
         n = relabeled.max()
         
     else:
@@ -422,6 +413,116 @@ def label(
         )
 
     return (relabeled, n)
+
+
+def merge_labels_across_chunk_boundaries(
+        labels,
+        overlap_depth=0,
+        iou_threshold=0.8,
+        structure=None,
+        wrap_axes=None,
+        trim_overlap=True,
+        produce_sequential_labels=True,
+        ):
+    """
+    Merge labels across chunk boundaries.
+
+    Each chunk in ``labels`` has been labeled independently, and the labels
+    in different chunks may overlap. This function tries to merge labels across
+    chunk boundaries using a strategy dependent on ``overlap``:
+    - If ``overlap > 0``, the overlap region between chunks is used to
+      determine which between each pair of chunks should be merged.
+    - If ``overlap == 0``, labels that touch across chunk boundaries are merged.
+
+    Parameters
+    ----------
+    labels : dask array of int
+        The input labeled array, where each chunk is independently labeled.
+    overlap_depth : int, optional
+        The size of the overlap region between chunks, e.g. as produced by
+        `dask.array.overlap` or `map_overlap`. Default is 0.
+    iou_threshold : float, optional
+        If ``overlap > 0``, the intersection-over-union (IoU) between labels
+        in the overlap region is used to determine which labels should be
+        merged. If the IoU between two labels is greater than ``iou_threshold``,
+        they are merged. Default is 0.8.
+    structure : array of bool, optional
+        Structuring element for determining connectivity. If None, a
+        cross-shaped structuring element is used.
+    wrap_axes : tuple of int, optional
+        Should labels be wrapped across array boundaries, and if so which axes.
+        - (0,) only wrap over the 0th axis.
+        - (0, 1) wrap over the 0th and 1st axis.
+        - (0, 1, 3)  wrap over 0th, 1st and 3rd axis.
+    trim_overlap : bool, optional
+        If True, the overlap regions are trimmed from the output labels.
+        Default is True.
+
+    Returns
+    -------
+    dict with keys 'labels' and 'mapping'
+        'labels': dask array of int
+            The relabeled array, where labels have been merged across chunk
+            boundaries.
+        'mapping': dict
+            A mapping from old labels to new labels.
+    """
+
+    # Make labels unique across blocks by encoding the block ID into the labels.
+    # We use half the bits to encode the block ID and half the bits to encode
+    # the label ID within the block.
+    block_labeled_unique = _label._make_labels_unique(
+        labels, encoding_dtype=np.uint32)
+
+    # Now, build a label mapping that groups labels across blocks.
+    # We use this mapping to find connected components and then relabel each
+    # block according to those.
+    all_mappings = _label.label_adjacency_mapping(
+        block_labeled_unique,
+        structure,
+        wrap_axes=wrap_axes,
+        iou_threshold=iou_threshold,
+        overlap_depth=overlap_depth,
+    )
+
+    mapping = _label.connected_components_delayed(all_mappings)
+
+    relabeled = _label.relabel(
+        block_labeled_unique, mapping
+    )
+
+    relabeled = relabeled.astype(_label.LABEL_DTYPE)
+
+    if trim_overlap and overlap_depth > 0:
+        relabeled = da.overlap.trim_overlap(
+            relabeled, {i: overlap_depth for i in range(relabeled.ndim)},
+            boundary='none',
+        )
+
+    if produce_sequential_labels:
+        relabeled = relabel_sequential(relabeled)
+
+    return {
+        'labels': relabeled,
+        'mapping': mapping,
+    }
+
+
+def relabel_sequential(labels):
+    """
+    Relabel the labels in ``labels`` to be sequential starting at 1.
+    """
+
+    u = da.unique(
+        da.concatenate(
+            [da.unique(b) for b in labels.blocks]
+            )
+        )
+    mapping = delayed(lambda x: {k: v for k, v in zip(x, np.arange(len(x)))})(u)
+
+    relabeled = _label.relabel(labels, mapping)
+
+    return relabeled
 
 
 def labeled_comprehension(image,

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -5,6 +5,7 @@ import operator
 import dask
 import dask.array as da
 import numpy as np
+import pandas as pd
 import scipy.ndimage
 import scipy.sparse
 import scipy.sparse.csgraph
@@ -25,16 +26,16 @@ def _get_connected_components_dtype():
 CONN_COMP_DTYPE = _get_connected_components_dtype()
 
 
-def relabel_blocks(block_labeled, new_labeling):
+def relabel_blocks(block_labeled, mapping):
     """
-    Relabel a block-labeled array based on ``new_labeling``.
+    Relabel a block-labeled array based on ``mapping``.
 
     Parameters
     ----------
     block_labeled : array of int
         The input label array.
-    new_labeling : 1D array of int
-        A new labeling, such that ``labeling[i] = j`` implies that
+    mapping : dict
+        A label mapping, such that ``mapping[i] = j`` implies that
         any element in ``array`` valued ``i`` should be relabeled to ``j``.
 
     Returns
@@ -42,12 +43,37 @@ def relabel_blocks(block_labeled, new_labeling):
     relabeled : array of int, same shape as ``array``
         The relabeled input array.
     """
-    new_labeling = new_labeling.astype(LABEL_DTYPE)
-    relabeled = da.map_blocks(operator.getitem,
-                              new_labeling,
-                              block_labeled,
-                              dtype=LABEL_DTYPE,
-                              chunks=block_labeled.chunks)
+    
+    def relabel_block(block, mapping):
+        # pandas replace works well for both dense and sparse mappings
+        # including large integer labels
+        s = pd.Series(block.flatten())
+        result = s.replace(mapping).to_numpy()
+        return result.reshape(block.shape)
+
+    relabeled = block_labeled.map_blocks(
+        relabel_block,
+        mapping=mapping,
+        dtype=block_labeled.dtype
+    )
+
+    return relabeled
+
+
+def relabel_sequential(labels):
+    """
+    Relabel the labels in ``labels`` to be sequential starting at 1.
+    """
+
+    u = da.unique(
+        da.concatenate(
+            [da.unique(b) for b in labels.blocks]
+            )
+        )
+    mapping = dask.delayed(lambda x: {k: v for k, v in zip(x, np.arange(len(x)))})(u)
+
+    relabeled = relabel_blocks(labels, mapping)
+
     return relabeled
 
 
@@ -115,7 +141,6 @@ def _across_block_label_grouping_delayed(face, structure):
     return da.from_delayed(grouped, shape=(2, np.nan), dtype=LABEL_DTYPE)
 
 
-@dask.delayed
 def _to_csr_matrix(i, j, n):
     """Using i and j as coo-format coordinates, return csr matrix."""
     v = np.ones_like(i)
@@ -123,14 +148,14 @@ def _to_csr_matrix(i, j, n):
     return mat.tocsr()
 
 
-def label_adjacency_graph(labels, structure, nlabels, wrap_axes=None):
+def label_adjacency_mapping(labels, structure, wrap_axes=None):
     """
     Adjacency graph of labels between chunks of ``labels``.
 
     Each chunk in ``labels`` has been labeled independently, and the labels
     in different chunks are guaranteed to be unique.
 
-    Here we construct a graph connecting labels in different chunks that
+    Here we construct a mapping connecting labels in different chunks that
     correspond to the same logical label in the global volume. This is true
     if the two labels "touch" across the block face as defined by the input
     ``structure``.
@@ -141,9 +166,6 @@ def label_adjacency_graph(labels, structure, nlabels, wrap_axes=None):
         The input labeled array, where each chunk is independently labeled.
     structure : array of bool
         Structuring element, shape (3,) * labels.ndim.
-    nlabels : delayed int
-        The total number of labels in ``labels`` *before* correcting for
-        global consistency.
     wrap_axes : tuple of int, optional
         Should labels be wrapped across array boundaries, and if so which axes.
         - (0,) only wrap over the 0th axis.
@@ -152,9 +174,9 @@ def label_adjacency_graph(labels, structure, nlabels, wrap_axes=None):
 
     Returns
     -------
-    mat : delayed scipy.sparse.csr_matrix
-        This matrix has value 1 at (i, j) if label i is connected to
-        label j in the global volume, 0 everywhere else.
+    mat : delayed dict
+        This is a mapping such that if ``mapping[i] = j``, then labels ``i``
+        and ``j`` should be merged.
     """
 
     if structure is None:
@@ -171,10 +193,8 @@ def label_adjacency_graph(labels, structure, nlabels, wrap_axes=None):
         all_mappings.append(mapped)
 
     all_mappings = da.concatenate(all_mappings, axis=1)
-    i, j = all_mappings
-    mat = _to_csr_matrix(i, j, nlabels + 1)
 
-    return mat
+    return all_mappings
 
 
 def _chunk_faces(chunks, shape, structure, wrap_axes=None):
@@ -302,13 +322,98 @@ def block_ndi_label_delayed(block, structure):
     return labeled, n
 
 
-def connected_components_delayed(csr_matrix):
+@dask.delayed(nout=2)
+def connected_components_delayed(all_mappings):
     """
-    Delayed version of scipy.sparse.csgraph.connected_components.
+    Use scipy.sparse.csgraph.connected_components to find the connected
+    components of the graph defined by ``all_mappings``.
 
-    This version only returns the (delayed) connected component labelling, not
-    the number of components.
+    Return the mapping from old labels to new labels, and the number of
+    labels that were collapsed.
     """
-    conn_comp = dask.delayed(scipy.sparse.csgraph.connected_components, nout=2)
-    return da.from_delayed(conn_comp(csr_matrix, directed=False)[1],
-                           shape=(np.nan,), dtype=CONN_COMP_DTYPE)
+
+    if not all_mappings.shape[1]:
+        return {}, 0
+
+    # relabel all_mappings to consecutive integers starting at 1
+    unique_labels, unique_inverse = np.unique(
+        all_mappings,
+        return_inverse=True)
+
+    unique_labels_new = np.arange(
+        0, len(unique_labels), dtype=all_mappings.dtype)
+
+    relabeled_mappings = unique_labels_new[unique_inverse]
+
+    i, j = relabeled_mappings
+    csr_matrix = _to_csr_matrix(i, j, len(unique_labels) + 1)
+
+    conn_comp = scipy.sparse.csgraph.connected_components
+    new_labeling = unique_labels[conn_comp(csr_matrix, directed=False)[1]]
+
+    n_red = len(unique_labels) - len(np.unique(new_labeling)) + 1
+
+    mapping = {k: v for k, v in zip(unique_labels, new_labeling)}
+
+    return mapping, n_red
+
+
+def _encode_label(label, block_id, encoding_dtype=np.uint32):
+    bit_shift = np.iinfo(encoding_dtype).bits // 2
+    nonzero = label != 0
+    label = np.array(label, dtype=encoding_dtype)
+    label[nonzero] = label[nonzero] + (block_id << bit_shift)
+    return label
+
+
+# def _decode_label(encoded_label, encoding_dtype=np.uint32, decoding_dtype=np.uint16):
+#     bit_shift = np.iinfo(encoding_dtype).bits // 2
+#     label = encoded_label & ((1 << bit_shift) - 1)
+#     # block_id = encoded_label >> bit_shift
+#     return label.astype(decoding_dtype)
+
+
+def _make_labels_unique(labels, encoding_dtype=np.uint16):
+    """
+    Make labels unique across blocks by using
+    - lower bits to encode the block ID
+    - higher bits to encode the label ID within the block
+
+    Parameters
+    ----------
+    labels: dask array
+        Array containing labels
+    encoding_dtype: numpy dtype
+        Dtype used to encode the labels.
+        Must be an unsigned integer dtype.
+    """
+
+    assert np.issubdtype(encoding_dtype, np.unsignedinteger), \
+        "encoding_dtype must be an unsigned integer dtype"
+        
+    def _unique_block_labels(
+            block, block_id=None,
+            encoding_dtype=encoding_dtype,
+            numblocks=labels.numblocks
+            ):
+        
+        if block_id is None:
+            block_id = (0,) * block.ndim
+
+        block_id = np.ravel_multi_index(
+            block_id,
+            numblocks,
+            )
+        block = block.astype(encoding_dtype)
+        block = _encode_label(block, block_id, encoding_dtype=encoding_dtype)
+
+        return block
+
+    unique_labels = da.map_blocks(_unique_block_labels,
+                                  labels,
+                                  dtype=encoding_dtype,
+                                  chunks=labels.chunks,
+                                  encoding_dtype=encoding_dtype,
+                                  )
+    
+    return unique_labels

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -108,10 +108,10 @@ def _across_block_label_grouping(
     face_dims : list of int
         The dimensions along which the face extends.
     iou_threshold : float, optional
-        If ``overlap_depth > 0``, the intersection-over-union (IoU) between labels
-        in the overlap region is used to determine which labels should be
-        merged. If the IoU between two labels is greater than ``iou_threshold``,
-        they are merged. Default is 0.8.
+        If ``overlap_depth > 0``, the intersection-over-union (IoU) between
+        labels in the overlap region is used to determine which labels should
+        be merged. If the IoU between two labels is greater than
+        ``iou_threshold``, they are merged. Default is 0.8.
 
     Returns
     -------
@@ -136,7 +136,7 @@ def _across_block_label_grouping(
     if not overlap_depth:
 
         # merge touching labels
-        
+
         common_labels = scipy.ndimage.label(face, structure)[0]
         # when processing labels that don't come from ndimage.label, we need to
         # ensure equal dtypes
@@ -188,7 +188,8 @@ def _across_block_label_grouping(
                 intersection = np.sum((face1 == l1) * (face2 == l2))
                 if intersection == 0:
                     continue
-                union = np.sum(face1 == l1) + np.sum(face2 == l2) - intersection
+                union = \
+                    np.sum(face1 == l1) + np.sum(face2 == l2) - intersection
                 iou = intersection / union
                 if iou > iou_threshold:
                     matching_pairs.append((l1, l2))
@@ -202,7 +203,8 @@ def _across_block_label_grouping(
 def _across_block_label_grouping_delayed(**across_block_label_grouping_kwargs):
     """Delayed version of :func:`_across_block_label_grouping`."""
     _across_block_label_grouping_ = dask.delayed(_across_block_label_grouping)
-    grouped = _across_block_label_grouping_(**across_block_label_grouping_kwargs)
+    grouped = _across_block_label_grouping_(
+        **across_block_label_grouping_kwargs)
     return da.from_delayed(grouped, shape=(2, np.nan), dtype=LABEL_DTYPE)
 
 
@@ -214,12 +216,12 @@ def _to_csr_matrix(i, j, n):
 
 
 def label_adjacency_mapping(
-        labels,
-        structure=None,
-        wrap_axes=None,
-        overlap_depth=None,
-        iou_threshold=0.8,
-    ):
+            labels,
+            structure=None,
+            wrap_axes=None,
+            overlap_depth=None,
+            iou_threshold=0.8,
+        ):
     """
     Adjacency graph of labels between chunks of ``labels``.
 
@@ -278,9 +280,9 @@ def label_adjacency_mapping(
 
 
 def _chunk_faces(
-    chunks, shape, structure,
-    wrap_axes=None, overlap_depth=0
-    ):
+        chunks, shape, structure,
+        wrap_axes=None, overlap_depth=0
+        ):
     """
     Return slices for two-pixel-wide boundaries between chunks.
 
@@ -376,8 +378,10 @@ def _chunk_faces(
                     else:
                         if overlap_depth > 0:
                             curr_slice.append(slice(
-                                slices[ind_curr_block][dim].stop - 2 * overlap_depth,
-                                slices[ind_curr_block][dim].stop + 2 * overlap_depth))
+                                slices[ind_curr_block][dim].stop -
+                                2 * overlap_depth,
+                                slices[ind_curr_block][dim].stop +
+                                2 * overlap_depth))
                         else:
                             curr_slice.append(slice(
                                 slices[ind_curr_block][dim].stop - 1,
@@ -462,7 +466,9 @@ def _encode_label(label, block_id, encoding_dtype=np.uint32):
     return label
 
 
-# def _decode_label(encoded_label, encoding_dtype=np.uint32, decoding_dtype=np.uint16):
+# def _decode_label(
+#     encoded_label, encoding_dtype=np.uint32, decoding_dtype=np.uint16
+# ):
 #     bit_shift = np.iinfo(encoding_dtype).bits // 2
 #     label = encoded_label & ((1 << bit_shift) - 1)
 #     # block_id = encoded_label >> bit_shift
@@ -486,13 +492,13 @@ def _make_labels_unique(labels, encoding_dtype=np.uint16):
 
     assert np.issubdtype(encoding_dtype, np.unsignedinteger), \
         "encoding_dtype must be an unsigned integer dtype"
-        
+
     def _unique_block_labels(
             block, block_id=None,
             encoding_dtype=encoding_dtype,
             numblocks=labels.numblocks
             ):
-        
+
         if block_id is None:
             block_id = (0,) * block.ndim
 
@@ -511,5 +517,5 @@ def _make_labels_unique(labels, encoding_dtype=np.uint16):
                                   chunks=labels.chunks,
                                   encoding_dtype=encoding_dtype,
                                   )
-    
+
     return unique_labels

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -161,10 +161,10 @@ def _across_block_label_grouping(
         slice2 = [slice(None)] * len(face.shape)
         for dim in range(face.ndim):
             if dim in face_dims:
-                # slice1[dim] = slice(-2 * overlap_depth, None)
-                # slice2[dim] = slice(0, 2 * overlap_depth)
-                slice1[dim] = slice(-1 * overlap_depth, None)
-                slice2[dim] = slice(0, 1 * overlap_depth)
+                slice1[dim] = slice(-2 * overlap_depth, None)
+                slice2[dim] = slice(0, 2 * overlap_depth)
+                # slice1[dim] = slice(-1 * overlap_depth, None)
+                # slice2[dim] = slice(0, 1 * overlap_depth)
             else:
                 slice1[dim] = slice(None)
                 slice2[dim] = slice(None)
@@ -195,8 +195,6 @@ def _across_block_label_grouping(
 
         grouped = np.array(matching_pairs).T if len(matching_pairs) > 0\
             else np.zeros((2, 0), dtype=face.dtype)
-        
-        # import pdb; pdb.set_trace()
 
     return grouped
 
@@ -257,7 +255,8 @@ def label_adjacency_mapping(
         structure = scipy.ndimage.generate_binary_structure(labels.ndim, 1)
 
     face_slice_infos = _chunk_faces(
-        labels.chunks, labels.shape, structure, wrap_axes=wrap_axes
+        labels.chunks, labels.shape, structure,
+        wrap_axes=wrap_axes, overlap_depth=overlap_depth
     )
     all_mappings = [da.empty((2, 0), dtype=LABEL_DTYPE, chunks=1)]
 
@@ -377,8 +376,8 @@ def _chunk_faces(
                     else:
                         if overlap_depth > 0:
                             curr_slice.append(slice(
-                                slices[ind_curr_block][dim].stop - 1 * overlap_depth,
-                                slices[ind_curr_block][dim].stop + 1 * overlap_depth))
+                                slices[ind_curr_block][dim].stop - 2 * overlap_depth,
+                                slices[ind_curr_block][dim].stop + 2 * overlap_depth))
                         else:
                             curr_slice.append(slice(
                                 slices[ind_curr_block][dim].stop - 1,

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -322,18 +322,17 @@ def block_ndi_label_delayed(block, structure):
     return labeled, n
 
 
-@dask.delayed(nout=2)
+@dask.delayed
 def connected_components_delayed(all_mappings):
     """
     Use scipy.sparse.csgraph.connected_components to find the connected
     components of the graph defined by ``all_mappings``.
 
-    Return the mapping from old labels to new labels, and the number of
-    labels that were collapsed.
+    Return the mapping from old labels to new labels.
     """
 
     if not all_mappings.shape[1]:
-        return {}, 0
+        return {}
 
     # relabel all_mappings to consecutive integers starting at 1
     unique_labels, unique_inverse = np.unique(
@@ -351,11 +350,13 @@ def connected_components_delayed(all_mappings):
     conn_comp = scipy.sparse.csgraph.connected_components
     new_labeling = unique_labels[conn_comp(csr_matrix, directed=False)[1]]
 
-    n_red = len(unique_labels) - len(np.unique(new_labeling)) + 1
-
     mapping = {k: v for k, v in zip(unique_labels, new_labeling)}
 
-    return mapping, n_red
+    return mapping
+
+
+def count_n_of_collapsed_labels(mapping):
+    return len(mapping.keys()) - len(set(mapping.values()))
 
 
 def _encode_label(label, block_id, encoding_dtype=np.uint32):

--- a/dask_image/ndmeasure/_utils/_label.py
+++ b/dask_image/ndmeasure/_utils/_label.py
@@ -441,7 +441,8 @@ def connected_components_delayed(all_mappings):
     unique_labels_new = np.arange(
         0, len(unique_labels), dtype=all_mappings.dtype)
 
-    relabeled_mappings = unique_labels_new[unique_inverse]
+    relabeled_mappings = unique_labels_new[unique_inverse].reshape(
+        all_mappings.shape)
 
     i, j = relabeled_mappings
     csr_matrix = _to_csr_matrix(i, j, len(unique_labels))
@@ -455,7 +456,9 @@ def connected_components_delayed(all_mappings):
 
 
 def count_n_of_collapsed_labels(mapping):
-    return len(mapping.keys()) - len(set(mapping.values()))
+    return np.array(
+        len(mapping.keys()) - len(set(mapping.values())))\
+            .astype(np.uint64)
 
 
 def _encode_label(label, block_id, encoding_dtype=np.uint32):

--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -883,12 +883,14 @@ def test_make_labels_unique():
 
 @pytest.mark.parametrize(
         "ndim, overlap_depth, produce_sequential_labels",
-        [(1, 0, False),
-         (1, 1, True),
-         (2, 0, False),
-         (2, 1, True),
-         (3, 0, False),
-         (3, 1, True)]
+        [
+            (1, 0, False),
+            (1, 1, True),
+            (2, 0, False),
+            (2, 1, True),
+            (3, 0, False),
+            (3, 1, True),
+        ]
 )
 def test_merge_labels_across_chunk_boundaries(
     ndim, overlap_depth, produce_sequential_labels
@@ -953,7 +955,8 @@ def test_merge_labels_across_chunk_boundaries(
     dim_segmentation_merged = dask_image.ndmeasure\
         .merge_labels_across_chunk_boundaries(
             dim_chunkwise_segmentation,
-            overlap_depth=overlap_depth
+            overlap_depth=overlap_depth,
+            iou_threshold=0,
         )['labels']
 
     dim_segmentation_merged_c = \


### PR DESCRIPTION
## PR

This PR contains work I've been wanting to discuss and push here for a while.

Highlights:
1. Improvements to `ndmeasure.label`:
    1. Implementation of the idea by @jakirkham and @jni to make labels unique by using the lower and upper bits of the label array (see [here](https://github.com/dask/dask-image/issues/199)). This improves parallelism at the expensive of returning non-contiguous labels.
    1. The current implementation of `ndmeasure.label` doesn't output contiguous (sequential) labels (also before implementing the point above). This PR adds a parameter `produce_sequential_labels` to `dask_image.ndmeasure.label` to output contiguous labels.
1. Implementation of a chunked version of `skimage.segmentation.relabel_sequential`: `ndmeasure.relabel_sequential` (this provides the functionality e.g. of the point above, happy to discuss whether the function should be public)
1. Implementation of `ndmeasure.merge_labels_across_chunk_boundaries` (details below)
    1. Use case 1: merge touching labels
    2. Use case 2: merge labels above a given IoU within the overlap.

## merge_labels_across_chunk_boundaries
What's the idea behind `ndmeasure.merge_labels_across_chunk_boundaries`?

### Visual abstract

Cases of overlap = 0 (top) and overlap > 0 (bottom)

<img width="1360" height="1052" alt="image" src="https://github.com/user-attachments/assets/78c58f5d-edbe-4915-8c3e-eb72eef57852" />


### Description

From the docstring:

```python
def merge_labels_across_chunk_boundaries(
        labels,
        overlap_depth=0,
        iou_threshold=0.8,
        structure=None,
        wrap_axes=None,
        trim_overlap=True,
        produce_sequential_labels=True,
        ):
    """
    Merge labels across chunk boundaries.

    Each chunk in ``labels`` has been labeled independently, and the labels
    in different chunks may overlap. This function tries to merge labels across
    chunk boundaries using a strategy dependent on ``overlap``:
    - If ``overlap > 0``, the overlap region between chunks is used to
      determine which between each pair of chunks should be merged.
    - If ``overlap == 0``, labels that touch across chunk boundaries are merged.

    Parameters
    ----------
    labels : dask array of int
        The input labeled array, where each chunk is independently labeled.
    overlap_depth : int, optional
        The size of the overlap region between chunks, e.g. as produced by
        `dask.array.overlap` or `map_overlap`. Default is 0.
    iou_threshold : float, optional
        If ``overlap > 0``, the intersection-over-union (IoU) between labels
        in the overlap region is used to determine which labels should be
        merged. If the IoU between two labels is greater than ``iou_threshold``,
        they are merged. Default is 0.8.
    structure : array of bool, optional
        Structuring element for determining connectivity. If None, a
        cross-shaped structuring element is used.
    wrap_axes : tuple of int, optional
        Should labels be wrapped across array boundaries, and if so which axes.
        - (0,) only wrap over the 0th axis.
        - (0, 1) wrap over the 0th and 1st axis.
        - (0, 1, 3)  wrap over 0th, 1st and 3rd axis.
    trim_overlap : bool, optional
        If True, the overlap regions are trimmed from the output labels.
        Default is True.
    """
```

### Example

Consider the following problem.

The user wants to segment a large input image, i.e. a dask array.

```python
import numpy as np
import dask.array as da
import skimage
import matplotlib.pyplot as plt

dim = da.from_array(
    skimage.data.cells3d()[:, 1, :, :].max(axis=0), chunks=(110, 110))
```
<img width="400" alt="image" src="https://github.com/user-attachments/assets/057088d0-ff92-42f2-a234-4c85a602d0af" />

and has a segmentation method that cannot be applied on the entire image (e.g. memory or method constraints) but works well on regions of the input image. The user can use `map_overlap` to apply the segmentation on the chunks of the input image and include overlap so that the segmentation method performs well on the chunk boundaries:

```python
model = models.Cellpose(gpu=False, model_type='cyto')

dseg = dim.map_overlap(
        lambda x: model.eval(x, diameter=None, channels=[0, 0])[0],
        dtype=np.uint16,
        depth=10,
    ).persist()

plt.figure()
plt.imshow(dseg)
```
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4ac1fedb-062c-49aa-aea3-dbd4cb97c8a7" />

At this point, the user faces two challenges:
1. the obtained segmentation labels show boundary artefacts and
3. they are not unique.

This is where `ndmeasure.merge_labels_across_chunk_boundaries` comes in to merge labels across chunk boundaries.

#### First use case / usage pattern
Similarly to the implementation of `ndmeasure.label` and e.g. the approach provided in [distributed cellpose](https://github.com/MouseLand/cellpose/pull/1062) (ping @GFleishman), one approach for merging labels consists in merging labels that touch across chunk boundaries. `ndmeasure.merge_labels_across_chunk_boundaries` allows to do this in a way that's agnostic of the segmentation method:

```python
import dask_image.ndmeasure

dseg_merged = dask_image.ndmeasure.merge_labels_across_chunk_boundaries(
    dseg
)['labels']

plt.figure()
plt.imshow(dseg_merged)
```

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ce286209-2ea0-4157-9880-001a9f6b8fbf" />

#### Second use case

The approach above joins all labels that form part of the same connected component in a boundary slice of thickness one. This can lead to artefacts. In fact, the example image above contains two merged cells which are clearly separated in the chunkwise segmentation. To separate these, `dask_image.ndmeasure.merge_labels_across_chunk_boundaries` has the option to merge labels based on the IoU within an overlap region.

```python
dseg = da.overlap.overlap(
        dim, depth={0: 10, 1: 10},
        boundary='none'
    ).map_blocks(
        lambda x: model.eval(x, diameter=None, channels=[0, 0])[0],
        dtype=np.uint16
    ).persist()

dseg_merged = dask_image.ndmeasure.merge_labels_across_chunk_boundaries(
    dseg, overlap_depth=10, iou_threshold=0.8,
)['labels'].compute(scheduler='single-threaded')

plt.figure()
plt.imshow(dseg_merged)
```
<img width="400" alt="image" src="https://github.com/user-attachments/assets/32d0f856-888b-49ef-b43a-5e097f8a45d3" />

The labels of the two cells below which previously had been joined now remain separated.

## Finally

In my personal projects it's been useful to have a function that merges labels across chunks. I think `dask-image` could be a good place for providing such functionality to the community and I've had some offline feedback at meetings that this could be useful. Happy about any further feedback / discussion over here!
