### PR TITLE
Recommend dask.array.image.imread over dask-image imread

### DIFF
--- a/dask_image/imread/__init__.py
+++ b/dask_image/imread/__init__.py
@@ -31,6 +31,11 @@ def imread(fname, nframes=1, *, arraytype="numpy"):
     -------
     array : dask.array.Array
         A Dask Array representing the contents of all image files.
+
+    Warnings
+    --------
+    There are several known issues with this function, and users are
+    recommended to use `dask.array.image.imread` instead.
     """
 
     sfname = str(fname)


### PR DESCRIPTION
I recently ran into https://github.com/dask/dask-image/issues/359, and spent a lot of time scratching my head. Eventually I found that issue, and the recommendation to use `dask.array.image.imread` instead.

As per https://github.com/dask/dask-image/issues/356#issuecomment-2003835954, I've added a warning to the documentation so hopefully users spot this quicker.