### PR TITLE
Compatibility with Numpy v2.4

### DIFF
--- a/tests/test_dask_image/test_ndmeasure/test_core.py
+++ b/tests/test_dask_image/test_ndmeasure/test_core.py
@@ -142,7 +142,7 @@ def test_measure_props(funcname, shape, chunks, has_lbls, ind):
     if (
         funcname == "median" and
         ind is not None and
-        not np.in1d(np.atleast_1d(ind), lbls).all()
+        not np.isin(np.atleast_1d(ind), lbls).all()
     ):
         pytest.skip("SciPy's `median` mishandles missing labels.")
 


### PR DESCRIPTION
* Do not use the deprecated numpy.in1d
