### PR TITLE
Make dataframe dependencies optional

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate dask-image-testenv
-          python -m pip install -e .
+          python -m pip install -e .[dataframe]
           conda list
 
       - name: Run tests
@@ -48,6 +48,27 @@ jobs:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
           path-to-lcov: coverage.lcov
+
+  test-minimal:
+    # Verify dask-image works without the optional `dataframe` extras
+    # (i.e. without pandas and dask[dataframe]).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dask-image without dataframe extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
+
+      - name: Run tests (find_objects tests are skipped automatically)
+        run: pytest -v
 
   coveralls:
     needs: test

--- a/dask_image/ndmeasure/__init__.py
+++ b/dask_image/ndmeasure/__init__.py
@@ -9,7 +9,6 @@ import dask.config as dask_config
 
 import dask.array as da
 import dask.bag as db
-import dask.dataframe as dd
 import numpy as np
 
 from . import _utils
@@ -228,9 +227,21 @@ def find_objects(label_image):
 
     Notes
     -----
-    You must have the optional dependency ``dask[dataframe]`` installed
-    to use the ``find_objects`` function.
+    You must have the optional dependencies ``dask[dataframe]`` and
+    ``pandas`` installed to use the ``find_objects`` function. They can
+    be installed together via the ``dataframe`` extras group:
+    ``pip install dask-image[dataframe]``.
     """
+    try:
+        import pandas  # noqa: F401  # used by the private helpers below
+        import dask.dataframe as dd
+    except ImportError as e:
+        raise ImportError(
+            "dask_image.ndmeasure.find_objects requires the optional "
+            "dependencies `dask[dataframe]` and `pandas`. Install them "
+            "with `pip install dask-image[dataframe]`."
+        ) from e
+
     if label_image.dtype.char not in np.typecodes['AllInteger']:
         raise ValueError("find_objects only accepts integer dtype arrays")
 

--- a/dask_image/ndmeasure/_utils/_find_objects.py
+++ b/dask_image/ndmeasure/_utils/_find_objects.py
@@ -1,7 +1,5 @@
 import numpy as np
-import pandas as pd
 from dask.delayed import Delayed
-import dask.dataframe as dd
 import dask.config as dask_config
 
 
@@ -24,6 +22,8 @@ def _find_bounding_boxes(x, array_location):
     This alternative function returns a pandas dataframe,
     with one row per object found in the image chunk.
     """
+    import pandas as pd
+
     unique_vals = np.unique(x)
     unique_vals = unique_vals[unique_vals != 0]
     result = {}
@@ -53,6 +53,8 @@ def _combine_slices(slices):
 
 def _merge_bounding_boxes(x, ndim):
     "Merge the bounding boxes describing objects over multiple image chunks."
+    import pandas as pd
+
     x = x.dropna()
     data = {}
     # For each dimension in the array,
@@ -72,6 +74,9 @@ def _merge_bounding_boxes(x, ndim):
 
 def _find_objects(ndim, df1, df2):
     """Main utility function for find_objects."""
+    import pandas as pd
+    import dask.dataframe as dd
+
     meta = dd.utils.make_meta([(i, object) for i in range(ndim)])
     if isinstance(df1, Delayed):
         with dask_config.set({'dataframe.convert-string': False}):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,8 @@ dataframe = [
 test = [
     "build >=1.2.1",
     "coverage >=7.2.1",
-    "dask[dataframe] >=2024.4.1",
     "flake8 >=6.0.0",
     "Flake8-pyproject",
-    "pandas >=2.0.0",
     "pytest >=7.2.2",
     "pytest-cov >=4.0.0",
     "pytest-flake8 >=1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,6 @@ include = [
 [tool.pytest.ini_options]
 addopts = "--flake8"
 markers = "cupy"
+
+[tool.flake8]
+exclude = ["dask_image/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,20 +24,25 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "dask[array,dataframe] >=2024.4.1",
+    "dask[array] >=2024.4.1",
     "numpy >=1.18",
     "scipy >=1.7.0",
-    "pandas >=2.0.0",
     "pims >=0.4.1",
     "tifffile >=2020.10.1",
 ]
 
 [project.optional-dependencies]
+dataframe = [
+    "dask[dataframe] >=2024.4.1",
+    "pandas >=2.0.0",
+]
 test = [
     "build >=1.2.1",
     "coverage >=7.2.1",
+    "dask[dataframe] >=2024.4.1",
     "flake8 >=6.0.0",
     "Flake8-pyproject",
+    "pandas >=2.0.0",
     "pytest >=7.2.2",
     "pytest-cov >=4.0.0",
     "pytest-flake8 >=1.1.1",

--- a/tests/test_dask_image/test_ndfilters/test__generic.py
+++ b/tests/test_dask_image/test_ndfilters/test__generic.py
@@ -70,9 +70,9 @@ def test_generic_filter_shape_type(da_func):
 @pytest.mark.parametrize(
     "function, size, footprint",
     [
-        (lambda x: x, 1, None),
-        (lambda x: x, (1, 1), None),
-        (lambda x: x, None, np.ones((1, 1))),
+        (lambda x: x[0], 1, None),
+        (lambda x: x[0], (1, 1), None),
+        (lambda x: x[0], None, np.ones((1, 1))),
     ],
 )
 def test_generic_filter_identity(sp_func, da_func, function, size, footprint):
@@ -94,7 +94,7 @@ def test_generic_filter_identity(sp_func, da_func, function, size, footprint):
     ],
 )
 def test_generic_filter_comprehensions(da_func):
-    da_wfunc = lambda arr: da_func(arr, lambda x: x, 1)  # noqa: E731
+    da_wfunc = lambda arr: da_func(arr, lambda x: x[0], 1)  # noqa: E731
 
     np.random.seed(0)
 

--- a/tests/test_dask_image/test_ndmeasure/test_find_objects.py
+++ b/tests/test_dask_image/test_ndmeasure/test_find_objects.py
@@ -1,10 +1,12 @@
-import dask.array as da
-import dask.dataframe as dd
-import numpy as np
-import pandas as pd
 import pytest
 
-import dask_image.ndmeasure
+pd = pytest.importorskip("pandas")
+dd = pytest.importorskip("dask.dataframe")
+
+import dask.array as da  # noqa: E402
+import numpy as np  # noqa: E402
+
+import dask_image.ndmeasure  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/test_dask_image/test_ndmeasure/test_find_objects_no_dataframe.py
+++ b/tests/test_dask_image/test_ndmeasure/test_find_objects_no_dataframe.py
@@ -1,0 +1,37 @@
+"""
+Test that ``find_objects`` raises a helpful ``ImportError`` when the
+optional ``dask[dataframe]`` / ``pandas`` dependencies are not installed.
+
+This is skipped if both dependencies are installed.
+
+"""
+import dask.array as da
+import pytest
+
+import dask_image.ndmeasure
+
+
+try:
+    import pandas  # noqa: F401
+    import dask.dataframe  # noqa: F401
+    dataframe_available = True
+except ImportError:
+    dataframe_available = False
+
+
+@pytest.mark.skipif(
+    dataframe_available,
+    reason="dataframe dependencies are installed; "
+           "ImportError path only triggers without them",
+)
+def test_find_objects_raises_import_error_without_pandas():
+    label_image = da.zeros((3, 3), dtype=int, chunks=(3, 3))
+    with pytest.raises(
+        ImportError,
+        match=(
+            r"dask_image\.ndmeasure\.find_objects requires the optional "
+            r"dependencies `dask\[dataframe\]` and `pandas`\. "
+            r"Install them with `pip install dask-image\[dataframe\]`\."
+        ),
+    ):
+        dask_image.ndmeasure.find_objects(label_image)


### PR DESCRIPTION
As discussed in https://github.com/dask/dask-image/issues/428, this makes the dataframe dependencies optional. I added a CI job to make sure everything works without the optional dependencies