### PR TITLE
Security: Use of assert statements for input validation in production code

### DIFF
--- a/dask_image/ndfourier/_utils.py
+++ b/dask_image/ndfourier/_utils.py
@@ -7,13 +7,15 @@ import numpy as np
 
 
 def _get_freq_grid(shape, chunks, axis, n, dtype=float):
-    assert len(shape) == len(chunks)
+    if len(shape) != len(chunks):
+        raise ValueError("shape and chunks must have the same length")
 
     shape = tuple(shape)
     dtype = np.dtype(dtype).type
 
-    assert (issubclass(dtype, numbers.Real) and
-            not issubclass(dtype, numbers.Integral))
+    if not (issubclass(dtype, numbers.Real) and
+            not issubclass(dtype, numbers.Integral)):
+        raise TypeError("dtype must be a non-integral real number")
 
     axis = axis % len(shape)
 
@@ -33,8 +35,9 @@ def _get_freq_grid(shape, chunks, axis, n, dtype=float):
 def _get_ang_freq_grid(shape, chunks, axis, n, dtype=float):
     dtype = np.dtype(dtype).type
 
-    assert (issubclass(dtype, numbers.Real) and
-            not issubclass(dtype, numbers.Integral))
+    if not (issubclass(dtype, numbers.Real) and
+            not issubclass(dtype, numbers.Integral)):
+        raise TypeError("dtype must be a non-integral real number")
 
     pi = dtype(np.pi)
 


### PR DESCRIPTION
## Summary

Security: Use of assert statements for input validation in production code

## Problem

**Severity**: `Medium` | **File**: `dask_image/ndfourier/_utils.py:L18`

The file `dask_image/ndfourier/_utils.py` uses Python `assert` statements for input validation (e.g., lines checking `issubclass(dtype, numbers.Real)`). Assert statements can be disabled globally when Python is run with the `-O` (optimize) flag, which would bypass these checks entirely. This could allow invalid inputs to propagate through the code, potentially causing crashes, incorrect results, or undefined behavior in production environments where optimized Python execution is used.

## Solution

Replace `assert` statements with proper `if` conditions that raise appropriate exceptions (e.g., `ValueError`, `TypeError`). For example, instead of `assert (issubclass(dtype, numbers.Real) and not issubclass(dtype, numbers.Integral))`, use `if not (issubclass(dtype, numbers.Real) and not issubclass(dtype, numbers.Integral)): raise TypeError("dtype must be a non-integral real number")`.

## Changes

- `dask_image/ndfourier/_utils.py` (modified)